### PR TITLE
[ENH] owdatasets: Add a single cell version of the datasets widget

### DIFF
--- a/orangecontrib/single_cell/widgets/owdatasets.py
+++ b/orangecontrib/single_cell/widgets/owdatasets.py
@@ -1,0 +1,33 @@
+import sys
+
+from AnyQt.QtWidgets import QApplication
+
+import Orange.widgets.data.owdatasets
+
+
+class OWscDataSets(Orange.widgets.data.owdatasets.OWDataSets):
+    name = "Data Sets"
+    description = "Load a data set from an online repository"
+    icon = "icons/DataSets.svg"
+    priority = 20
+
+    INDEX_URL = "http://datasets.orange.biolab.si/sc/"
+    DATASET_DIR = "sc-datasets"
+
+
+def main(args=None):
+    if args is None:
+        args = sys.argv
+
+    app = QApplication(list(args))
+    w = OWscDataSets()
+    w.show()
+    w.raise_()
+    rv = app.exec_()
+    w.saveSettings()
+    w.onDeleteWidget()
+    return rv
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Introduces a copy of Orange's Data Sets widget, pointing to a single cell specific repository.

Depends on https://github.com/biolab/orange3/pull/2758, which needs to be merged first.