### PR TITLE
Soft move t-SNE to Unsupervised category

### DIFF
--- a/orangecontrib/single_cell/launcher/__init__.py
+++ b/orangecontrib/single_cell/launcher/__init__.py
@@ -117,7 +117,7 @@ class SCOrangeLauncher:
         wd = registry.WidgetDiscovery.widget_description
         def widget_description(self, module, widget_name=None,
                                category_name=None, distribution=None):
-            """Move tSNE widget to Visualize category
+            """Move t-SNE widget to Unsupervised category
 
             A better way to do this would be to change the behaviour of the
             widget_description method to *not* overwrite the category when
@@ -128,7 +128,7 @@ class SCOrangeLauncher:
                 self, module, widget_name, category_name, distribution)
 
             if desc.qualified_name == 'orangecontrib.single_cell.widgets.owtsne.OWtSNE':
-                desc.category = 'Visualize'
+                desc.category = 'Unsupervised'
             return desc
 
         registry.WidgetDiscovery.widget_description = widget_description

--- a/orangecontrib/single_cell/widgets/owtsne.py
+++ b/orangecontrib/single_cell/widgets/owtsne.py
@@ -138,7 +138,7 @@ class OWtSNE(OWWidget):
     name = "t-SNE"
     description = "Two-dimensional data projection with t-SNE."
     icon = "icons/TSNE.svg"
-    priority = 245
+    priority = 3055
 
     class Inputs:
         data = Input("Data", Orange.data.Table, default=True)


### PR DESCRIPTION
##### Issue
t-SNE was before "soft-moved" to Visualize category of Orange. It better fits in category with PCA and MDS.

##### Description of changes
Moved.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
