### PR TITLE
[FIX] scnormalize: Convert variables from int->float after normalization

### DIFF
--- a/orangecontrib/single_cell/preprocess/scnormalize.py
+++ b/orangecontrib/single_cell/preprocess/scnormalize.py
@@ -31,11 +31,12 @@ class SCNormalizer(Preprocess):
                                 self.log_base)
         Y = data.get_column_view(self.equalize_var)[0] if self.equalize_var is not None else None
         proj.fit(data.X, Y)
+        attributes = [var.copy(compute_value=ScShared(proj, variable=var))
+                      for var in data.domain.attributes]
+        for var in attributes:
+            var.number_of_decimals = max(3, var.number_of_decimals)
         normalized_domain = Domain(
-            [var.copy(compute_value=ScShared(proj, variable=var))
-             for var in data.domain.attributes],
-            data.domain.class_vars, data.domain.metas)
-
+            attributes, data.domain.class_vars, data.domain.metas)
         return data.transform(normalized_domain)
 
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
After normalization variables still used the same number of shown decimal places. This is not correct for e.g. integers, which become floats after normalization.

##### Description of changes
After normalization, increase the number of shown decimal places to the default of 3 (but do not decrease it).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
