### PR TITLE
[ENH] Generalize 'Filter Cells' widget

### DIFF
--- a/orangecontrib/single_cell/tests/test_owfilter.py
+++ b/orangecontrib/single_cell/tests/test_owfilter.py
@@ -25,8 +25,8 @@ class TestOWFilterCells(WidgetTest):
             domain,
             [[0, 0, 0],
              [0, 0, 1],
-             [0, 1, 1],
-             [1, 1, 1]]
+             [0, 1, 2],
+             [1, 2, 3]]
         )
         self.send_signal(self.widget.Inputs.data, data)
 
@@ -36,11 +36,30 @@ class TestOWFilterCells(WidgetTest):
         self.widget.limit_lower = 2
         self.widget.commit()
         out = self.get_output(self.widget.Outputs.data)
-        self.assertTrue(len(out), 2)
+        self.assertEqual(len(out), 2)
         np.testing.assert_array_equal(
             np.count_nonzero(out.X, axis=1),
             [2, 3]
         )
+        self.widget.set_filter_type(OWFilter.Genes)
+        self.widget.commit()
+        out = self.get_output(self.widget.Outputs.data)
+        np.testing.assert_array_equal(
+            np.count_nonzero(out.X, axis=0),
+            [2, 3]
+        )
+        self.widget.set_filter_type(OWFilter.Data)
+        self.widget.commit()
+        out = self.get_output(self.widget.Outputs.data)
+        np.testing.assert_array_equal(
+            out.X,
+            [[0, 0, 0],
+             [0, 0, 0],
+             [0, 0, 2],
+             [0, 2, 3]]
+        )
+        # For paint code coverage
+        self.widget.grab()
+
         self.send_signal(self.widget.Inputs.data, None)
         self.assertIsNone(self.get_output(self.widget.Outputs.data))
-

--- a/orangecontrib/single_cell/widgets/owfilter.py
+++ b/orangecontrib/single_cell/widgets/owfilter.py
@@ -572,7 +572,7 @@ class SelectionLine(pg.InfiniteLine):
         painter.restore()
 
 
-def main(argv=None):
+def main(argv=None):  # pragma: no cover
     app = QApplication(list(argv or sys.argv))
     argv = app.arguments()
     w = OWFilter()
@@ -588,5 +588,5 @@ def main(argv=None):
     w.onDeleteWidget()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     sys.exit(main(sys.argv))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

References gh-40

##### Description of changes

Generalize *Filter Cells* widget to filter on cells (rows), genes (columns) or expression values.

In case the Data filter is in effect and data matrix is too big, sampling is employed to derive the  (approximate) density for display.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
