### PR TITLE
[FIX] Domain Context Handler: "metas in res" is deprecated

### DIFF
--- a/orangecontrib/single_cell/widgets/owclusterstatistics.py
+++ b/orangecontrib/single_cell/widgets/owclusterstatistics.py
@@ -21,7 +21,7 @@ class OWClusterStatistics(widget.OWWidget):
     want_main_area = False
     resizing_enabled = False
 
-    settingsHandler = settings.DomainContextHandler(metas_in_res=True)
+    settingsHandler = settings.DomainContextHandler()
     selected_attr = settings.ContextSetting("")
     autocommit = settings.Setting(True)
 

--- a/orangecontrib/single_cell/widgets/owclustervariation.py
+++ b/orangecontrib/single_cell/widgets/owclustervariation.py
@@ -16,7 +16,7 @@ class OWDifferentialExpression(widget.OWWidget):
     icon = "icons/ClusterVariation.svg"
     priority = 190
 
-    settingsHandler = DomainContextHandler(metas_in_res=True)
+    settingsHandler = DomainContextHandler()
     groupby = ContextSetting(None)
     auto_apply = Setting(True)
 

--- a/orangecontrib/single_cell/widgets/ownormalization.py
+++ b/orangecontrib/single_cell/widgets/ownormalization.py
@@ -26,7 +26,7 @@ class OWNormalization(widget.OWWidget):
     want_main_area = False
     resizing_enabled = False
 
-    settingsHandler = settings.DomainContextHandler(metas_in_res=True)
+    settingsHandler = settings.DomainContextHandler()
     selected_attr = settings.Setting(DEFAULT_CELL_NORM)
     autocommit = settings.Setting(True)
 

--- a/orangecontrib/single_cell/widgets/owscorecells.py
+++ b/orangecontrib/single_cell/widgets/owscorecells.py
@@ -16,7 +16,7 @@ class OWScoreCells(widget.OWWidget):
     icon = "icons/ScoreCells.svg"
     priority = 180
 
-    settingsHandler = DomainContextHandler(metas_in_res=True)
+    settingsHandler = DomainContextHandler()
     gene = ContextSetting(None)
     auto_apply = Setting(True)
 


### PR DESCRIPTION
##### Issue
```python
DomainContextHandler(metas_in_res=True)
```
is deprecated. It is not a valid parameter.


##### Description of changes
~Changed to~
```python
DomainContextHandler(DomainContextHandler.MATCH_VALUES_ALL)
```
~Maybe it should be changed to something else?~

Edit:
Now changed to:
```python
DomainContextHandler()
```


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
