### PR TITLE
[FIX] Score Genes: do not crash when no attributes

### DIFF
--- a/orangecontrib/single_cell/tests/test_owscoregenes.py
+++ b/orangecontrib/single_cell/tests/test_owscoregenes.py
@@ -1,0 +1,37 @@
+import unittest
+
+from orangecontrib.single_cell.widgets.owscoregenes import OWRank
+from Orange.widgets.tests.base import WidgetTest
+from Orange.data import DiscreteVariable, ContinuousVariable, Domain, Table
+
+
+class TestOWScoreGenes(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWRank)
+
+    def test_data_no_attributes(self):
+        """
+        Do not crash when data has not attributes. Show an error.
+        GH-51
+        """
+        w = self.widget
+
+        class_var = DiscreteVariable('Stage name', values=['STG1', 'STG2'])
+        metas = [ContinuousVariable('GeneName' + str(i)) for i in range(5)]
+        domain = Domain(attributes=[], class_vars=class_var, metas=metas)
+
+        data = Table(
+            domain,
+            [['STG1', 1, 2, 3, 4, 5],
+             ['STG1', 4, 4, 4, 4, 4],
+             ['STG1', 2, 3, 1, 1, 1],
+             ['STG2', -1, 0, 1, 0, 0]])
+
+        self.assertFalse(w.Error.no_attributes.is_shown())
+        for is_shown, input_data in ((True, data), (False, None)):
+            self.send_signal(w.Inputs.data, input_data)
+            self.assertEqual(is_shown, w.Error.no_attributes.is_shown())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/orangecontrib/single_cell/widgets/owscoregenes.py
+++ b/orangecontrib/single_cell/widgets/owscoregenes.py
@@ -302,6 +302,7 @@ class OWRank(OWWidget):
     class Error(OWWidget.Error):
         invalid_type = Msg("Cannot handle target variable type {}")
         inadequate_learner = Msg("Scorer {} inadequate: {}")
+        no_attributes = Msg("No attributes")
 
     def __init__(self):
         super().__init__()
@@ -409,6 +410,10 @@ class OWRank(OWWidget):
         self.Information.clear()
         self.Information.missings_imputed(
             shown=data is not None and data.has_missing())
+
+        if data is not None and not len(data.domain.attributes):
+            self.Error.no_attributes()
+            data = None
 
         self.data = data
         self.switchProblemType(ProblemType.CLASSIFICATION)


### PR DESCRIPTION
##### Issue
Connect data which has no attributes (_Dendritic cells and monocytes (markers)_, etc.) to widget **Score Genes**. Widget crashes.

##### Description of changes
Show an error.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
