### PR TITLE
OWLouvain: Remove splitter

### DIFF
--- a/orangecontrib/single_cell/widgets/owlouvainclustering.py
+++ b/orangecontrib/single_cell/widgets/owlouvainclustering.py
@@ -136,6 +136,8 @@ class OWLouvainClustering(widget.OWWidget):
     name = 'Louvain Clustering'
     icon = 'icons/LouvainClustering.svg'
 
+    want_main_area = False
+
     settingsHandler = DomainContextHandler()
 
     class Inputs:


### PR DESCRIPTION
##### Issue
Splitter appeared in Louvain widget. @BlazZupan I think this was the issue you pointed out.

##### Description of changes
Set `want_main_area` to false so as to remove splitter


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
