### PR TITLE
OWLouvain: Fix crash on graph output when data is none

### DIFF
--- a/orangecontrib/single_cell/widgets/owlouvainclustering.py
+++ b/orangecontrib/single_cell/widgets/owlouvainclustering.py
@@ -332,7 +332,8 @@ class OWLouvainClustering(widget.OWWidget):
         self.data = data
         self._invalidate_pca_projection()
         self.Outputs.annotated_data.send(None)
-        self.Outputs.graph.send(None)
+        if Graph is not None:
+            self.Outputs.graph.send(None)
         self.openContext(self.data)
 
         if self.data is None:


### PR DESCRIPTION
##### Issue
When network addon is not installed, the widget crashed when data was None.


##### Description of changes
Fixes issue. @mstrazar please confirm.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
