### PR TITLE
owfilter: Extend drag bounds for selection on the plot

### DIFF
--- a/orangecontrib/single_cell/widgets/owfilter.py
+++ b/orangecontrib/single_cell/widgets/owfilter.py
@@ -623,11 +623,11 @@ class ViolinPlot(pg.PlotItem):
         pen = QPen(self.palette().color(QPalette.Shadow), 1)
         hoverPen = QPen(self.palette().color(QPalette.Highlight), 1.5)
         cmax = SelectionLine(
-            angle=0, pos=xmax, movable=True, bounds=(xmin, xmax),
+            angle=0, pos=xmax, movable=True, bounds=(sample_min, sample_max),
             pen=pen, hoverPen=hoverPen
         )
         cmin = SelectionLine(
-            angle=0, pos=xmin, movable=True, bounds=(xmin, xmax),
+            angle=0, pos=xmin, movable=True, bounds=(sample_min, sample_max),
             pen=pen, hoverPen=hoverPen
         )
         cmax.setCursor(Qt.SizeVerCursor)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Selection state at the data bounds is unclear.

##### Description of changes

Extend drag bounds for selection on the plot

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
