### PR TITLE
t-SNE design to match Scatter Plot

### DIFF
--- a/orangecontrib/single_cell/widgets/owtsne.py
+++ b/orangecontrib/single_cell/widgets/owtsne.py
@@ -259,9 +259,8 @@ class OWtSNE(OWWidget):
 
         self.graph.box_zoom_select(self.controlArea)
 
-        gui.auto_commit(box, self, "auto_commit", "Send Selected",
-                        checkbox_label="Send selected automatically",
-                        box=None)
+        gui.auto_commit(self.controlArea, self, "auto_commit", "Send Selection",
+                        "Send Automatically")
 
         self.plot.getPlotItem().hideButtons()
         self.plot.setRenderHint(QPainter.Antialiasing)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
t-SNE had a different layout than Scatter Plot, even though these two widgets are very much the same.

##### Description of changes
Adjust t-SNE design to match the one of Scatter Plot. Commit box moved below plot controls and edited for minimalism.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
