### PR TITLE
[FIX] Louvain empty dataset

### DIFF
--- a/orangecontrib/single_cell/tests/test_owlouvain.py
+++ b/orangecontrib/single_cell/tests/test_owlouvain.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from Orange.data import Table, Domain
+from Orange.data import Table, Domain, ContinuousVariable
 from Orange.widgets.tests.base import WidgetTest
 from orangecontrib.single_cell.widgets.owlouvainclustering import \
     OWLouvainClustering
@@ -39,3 +39,14 @@ class TestOWLouvain(WidgetTest):
         clustering = output.get_column_view('Cluster')[0].astype(int)
         counts = np.bincount(clustering)
         np.testing.assert_equal(counts, sorted(counts, reverse=True))
+
+    def test_empty_dataset(self):
+        # Prepare a table with 5 rows with only meta attributes
+        meta = np.array([0] * 5)
+        meta_var = ContinuousVariable(name='meta_var')
+        table = Table.from_domain(domain=Domain([], metas=[meta_var]), n_rows=5)
+        table.get_column_view(meta_var)[0][:] = meta
+
+        self.send_signal(self.widget.Inputs.data, table)
+        self.widget.commit(force=True)
+        self.show()

--- a/orangecontrib/single_cell/widgets/owlouvainclustering.py
+++ b/orangecontrib/single_cell/widgets/owlouvainclustering.py
@@ -160,7 +160,8 @@ class OWLouvainClustering(widget.OWWidget):
     auto_commit = Setting(True)
 
     class Error(widget.OWWidget.Error):
-        general_error = Msg("Error occured during clustering\n{}")
+        empty_dataset = Msg('No features in data\n')
+        general_error = Msg('Error occured during clustering\n{}')
 
     class State(Enum):
         Pending, Running = range(2)
@@ -265,6 +266,11 @@ class OWLouvainClustering(widget.OWWidget):
 
         # We commit if auto_commit is on or when we force commit
         if not self.auto_commit and not force:
+            return
+
+        # Make sure the dataset is ok
+        if len(self.data.domain.attributes) < 1:
+            self.Error.empty_dataset()
             return
 
         # Prepare the tasks to run


### PR DESCRIPTION
##### Issue
Louvain crashed when the data had no variables (you could get this by removing all attributes in Select columns.


##### Description of changes
Show an error message when the dataset is empty.


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
