### PR TITLE
owtsne: Do not show attributes in combo boxes

### DIFF
--- a/orangecontrib/single_cell/widgets/owtsne.py
+++ b/orangecontrib/single_cell/widgets/owtsne.py
@@ -240,6 +240,12 @@ class OWtSNE(OWWidget):
         g = self.graph.gui
         box = g.point_properties_box(self.controlArea)
         self.models = g.points_models
+        # Because sc data frequently has many genes,
+        # showing all attributes in combo boxes can cause problems
+        # QUICKFIX: Remove a separator and attributes from order
+        # (leaving just the class and metas)
+        for model in self.models:
+            model.order = model.order[:-2]
 
         g.add_widgets(ids=[g.JitterSizeSlider], widget=box)
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Combo boxes do not work well with ~10k attributes and more.

##### Description of changes
As a (temporary) quick fix remove attributes from combo boxes, leaving only the class and meta vars.

@mstrazar @BlazZupan @astaric : Please take a look and test if this is OK
