### PR TITLE
[FIX] owmarkergenes: Fix proxy model mapping for selection

### DIFF
--- a/orangecontrib/single_cell/widgets/owmarkergenes.py
+++ b/orangecontrib/single_cell/widgets/owmarkergenes.py
@@ -146,9 +146,12 @@ class OWMarkerGenes(widget.OWWidget):
         self.commit()
 
     def commit(self):
-        table = self.view.model().sourceModel()
+        model = self.view.model()
+        assert isinstance(model, QSortFilterProxyModel)
+        table = model.sourceModel()
         assert isinstance(table, TableModel)
-        rows = [mi.row() for mi in self.view.selectionModel().selectedRows(0)]
+        rows = [model.mapToSource(mi).row()
+                for mi in self.view.selectionModel().selectedRows(0)]
         if rows:
             rows = table.mapToSourceRows(rows)
             output = table.source[rows]


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Marker genes outputs wrong rows for selection.

##### Description of changes

Map the selection through the sort/filter proxy mapping.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
