### PR TITLE
requirements: bump bioinformatics version, specify orange3 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Orange3
+Orange3>=3.12.0
 joblib>=0.11
 networkx
 pandas>=0.20
-orange3-bioinformatics==3.0.6
+orange3-bioinformatics==3.0.7


### PR DESCRIPTION
For https://github.com/biolab/orange3-single-cell/pull/125 to work, we introduced changes to OWDataSets in orange3 (https://github.com/biolab/orange3/pull/2950) which were included in release 3.12.0

Also, bump version for orange3-bioinformatics add-on.