### PR TITLE
[FIX] setup.py: Include data used in tutorials

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ KEYWORDS = (
 PACKAGES = find_packages()
 
 PACKAGE_DATA = {
-    'orangecontrib.single_cell': ['tutorials/*.ows'],
+    'orangecontrib.single_cell': ['tutorials/*'],
     'orangecontrib.single_cell.launcher': ['icons/*'],
     'orangecontrib.single_cell.widgets': ['icons/*', 'data/*']
 }


### PR DESCRIPTION
Package data files (.tab, .tab.gz) in addition to *.ows.