### PR TITLE
[FIX] owscdatasets: add missing GENE_ID_ATTRIBUTE

### DIFF
--- a/orangecontrib/single_cell/widgets/owscdatasets.py
+++ b/orangecontrib/single_cell/widgets/owscdatasets.py
@@ -9,7 +9,9 @@ from AnyQt.QtCore import Qt
 from Orange.widgets.gui import IndicatorItemDelegate
 
 from orangecontrib.bioinformatics.ncbi.taxonomy import shortname, common_taxids
-from orangecontrib.bioinformatics.widgets.utils.data import GENE_AS_ATTRIBUTE_NAME, TAX_ID
+from orangecontrib.bioinformatics.ncbi.gene import NCBI_ID
+from orangecontrib.bioinformatics.widgets.utils.data import GENE_AS_ATTRIBUTE_NAME, TAX_ID, GENE_ID_ATTRIBUTE
+
 
 
 class OWscDataSets(Orange.widgets.data.owdatasets.OWDataSets):
@@ -37,6 +39,7 @@ class OWscDataSets(Orange.widgets.data.owdatasets.OWDataSets):
         data = Orange.data.Table(path)
         data.attributes[TAX_ID] = info.taxid
         data.attributes[GENE_AS_ATTRIBUTE_NAME] = True  # Will all data sets have gene names in columns?
+        data.attributes[GENE_ID_ATTRIBUTE] = NCBI_ID
         return data
 
     def assign_delegates(self):


### PR DESCRIPTION
##### Issue
Widget did not annotate the output table properly. Gene id attribute was missing.

##### Description of changes
Add GENE_ID_ATTRIBUTE to the table attributes.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
