### PR TITLE
refactor out certificate name

### DIFF
--- a/installer/macos/sign-app.sh
+++ b/installer/macos/sign-app.sh
@@ -2,19 +2,19 @@
 
 DIST="$( cd "$(dirname "$0")/../../dist" ; pwd -P )"
 APP=$DIST/scOrange.app
-
+CERT="Developer ID Application: Univerza v Ljubljani"
 # Build app
 rm -rf $APP
 ./build-macos-app.sh $APP
 # Missing symlink Current messes with code signing
 ln -s 3.6 $APP/Contents/Frameworks/Python.framework/Versions/Current
 # sign bundle
-codesign -s "Developer ID" $APP/Contents/Frameworks/Python.framework/Versions/3.6
-codesign -s "Developer ID" $APP/Contents/MacOS/pip
-codesign -s "Developer ID" $APP
+codesign -s "$CERT" $APP/Contents/Frameworks/Python.framework/Versions/3.6
+codesign -s "$CERT" $APP/Contents/MacOS/pip
+codesign -s "$CERT" $APP
 
 VERSION=$($APP/Contents/MacOS/python -c 'import pkg_resources; print(pkg_resources.get_distribution("Orange3-SingleCell").version)')
 # Create disk image
 ./create-dmg-installer.sh --app $APP $DIST/scOrange-$VERSION.dmg
 # Sign disk image
-codesign -s "Developer ID" $DIST/scOrange-$VERSION.dmg
+codesign -s "$CERT" $DIST/scOrange-$VERSION.dmg


### PR DESCRIPTION
##### Issue
When multiple Developer ID certificates are installed, macOs bundles are not signed

##### Description of changes
Use a more specific certificate name, set it up in one place