### PR TITLE
[FIX] owmultisample: Fix current item selection

### DIFF
--- a/orangecontrib/single_cell/widgets/owmultisample.py
+++ b/orangecontrib/single_cell/widgets/owmultisample.py
@@ -5,8 +5,7 @@ from typing import Dict, Tuple, List, Optional
 from serverfiles import sizeformat
 
 from AnyQt.QtCore import (
-    Qt, QItemSelection, QItemSelectionModel, pyqtSlot as Slot,
-    QModelIndex, Signal
+    Qt, QItemSelectionModel, pyqtSlot as Slot, QModelIndex, Signal
 )
 from AnyQt.QtGui import (
     QStandardItemModel, QStandardItem, QIcon, QBrush, QColor
@@ -370,12 +369,9 @@ class OWMultiSample(owloaddata.OWLoadData):
     def select_item(self, index):
         if not isinstance(index, QModelIndex):
             index = self.view.model().index(index, 0)
-        selection = QItemSelection()
-        selection.select(index, index)
-        self.view.selectionModel().select(
-            selection,
-            QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows
-        )
+        self.view.selectionModel().setCurrentIndex(
+            index,
+            QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows)
         self.view.setFocus()
         self.repaint()
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The select_item() function did not set the current item, just the selection. So _update_view_cells_genes() sometimes updated the wrong row.

To test: add a file, add another file, change Input Data Structure, values are overwritten in the first row instead of the second.

##### Description of changes
Set the currentIndex and do the selection instead of just selecting.
