### PR TITLE
Multi Sample -> Load Data

### DIFF
--- a/orangecontrib/single_cell/widgets/owloaddata.py
+++ b/orangecontrib/single_cell/widgets/owloaddata.py
@@ -96,7 +96,7 @@ class RunaroundSettingsHandler(settings.SettingsHandler):
 
 
 class OWLoadData(widget.OWWidget):
-    name = "Load Data"
+    name = ""
     icon = "icons/LoadData.svg"
 
     class Outputs:

--- a/orangecontrib/single_cell/widgets/owmultisample.py
+++ b/orangecontrib/single_cell/widgets/owmultisample.py
@@ -129,9 +129,9 @@ class MultiSampleTreeView(QTreeView):
 
 
 class OWMultiSample(owloaddata.OWLoadData):
-    name = "Multi Sample"
+    name = "Load Data"
     description = "Load samples for multi-sample analysis"
-    icon = "icons/MultiSample.svg"
+    icon = "icons/LoadData.svg"
     priority = 155
 
     class Information(owloaddata.OWLoadData.Information):


### PR DESCRIPTION
Since the Multi Sample widget can just as well be used to load one data set and incorporates the Load Data widget, having both is redundant.

The original Load Data widget is removed and Multi Sample renamed to Load Data.