### PR TITLE
OWMultiSamples: Fix saving settings

### DIFF
--- a/orangecontrib/single_cell/tests/test_owmultisample.py
+++ b/orangecontrib/single_cell/tests/test_owmultisample.py
@@ -47,6 +47,7 @@ class TestOWMultiSample(WidgetTest):
         ))
 
     def test_settings(self):
+        self.widget.saveSettings()
         widget = self.create_widget(
             OWMultiSample, reset_default_settings=False
         )

--- a/orangecontrib/single_cell/widgets/owmultisample.py
+++ b/orangecontrib/single_cell/widgets/owmultisample.py
@@ -459,7 +459,10 @@ class OWMultiSample(owloaddata.OWLoadData):
             source_name = model.item(i, self._Header.source).text()
             self.samples.append((path, checked, source_name))
             self.loaders[path] = loader
-        self.saveSettings()
+
+    def saveSettings(self):
+        self.write_settings()
+        super().saveSettings()
 
     def read_settings(self):
         samples = self.samples.copy()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The widget did not save list of files into settings until data was loaded. 

##### Description of changes
List of files is saved into settings when the widget is deleted.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
