### PR TITLE
[ENH] Gene Markers: sets the name of the output file

### DIFF
--- a/orangecontrib/single_cell/widgets/owmarkergenes.py
+++ b/orangecontrib/single_cell/widgets/owmarkergenes.py
@@ -325,6 +325,7 @@ class OWMarkerGenes(widget.OWWidget):
         output.attributes[TAX_ID] = self.map_group_to_taxid.get(self.selected_group, '')
         # set columnd id flag
         output.attributes[GENE_ID_COLUMN] = HeaderLabels.GENE
+        output.name = "Marker Genes"
 
         self.Outputs.genes.send(output)
 


### PR DESCRIPTION
##### Issue
Gene Marker data set had a strange name of the data table that would then show in widgets like Cluster Analysis.

##### Description of changes
Widget now sets the data table name to "Marker Genes".

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
