### PR TITLE
Redefine the order of the widgets

### DIFF
--- a/orangecontrib/single_cell/widgets/owaligndatasets.py
+++ b/orangecontrib/single_cell/widgets/owaligndatasets.py
@@ -74,7 +74,7 @@ class OWAlignDatasets(widget.OWWidget):
     name = "Align Datasets"
     description = "Alignment of multiple datasets with a diagram of correlation visualization."
     icon = "icons/AlignDatasets.svg"
-    priority = 3050
+    priority = 240
 
     class Inputs:
         data = Input("Data", Table)

--- a/orangecontrib/single_cell/widgets/owbatchnorm.py
+++ b/orangecontrib/single_cell/widgets/owbatchnorm.py
@@ -53,7 +53,7 @@ class OWBatchNorm(OWWidget):
     name = "Batch Effect Removal"
     description = "Batch effect normalization on Single Cell data set."
     icon = "icons/BatchEffectRemoval.svg"
-    priority = 170
+    priority = 230
 
     class Inputs:
         data = Input("Data", Table)

--- a/orangecontrib/single_cell/widgets/owdotmatrix.py
+++ b/orangecontrib/single_cell/widgets/owdotmatrix.py
@@ -17,7 +17,7 @@ class OWDotMatrix(widget.OWWidget):
     name = "Dot Matrix"
     description = "Perform cluster analysis."
     icon = "icons/DotMatrix.svg"
-    priority = 2010
+    priority = 410
 
     class Inputs:
         data = Input("Data", Table, default=True)

--- a/orangecontrib/single_cell/widgets/owfilter.py
+++ b/orangecontrib/single_cell/widgets/owfilter.py
@@ -114,6 +114,7 @@ class OWFilter(widget.OWWidget):
     name = "Filter"
     icon = 'icons/Filter.svg'
     description = "Filter cells/genes"
+    priority = 210
 
     class Inputs:
         data = widget.Input("Data", Orange.data.Table)

--- a/orangecontrib/single_cell/widgets/owloaddata.py
+++ b/orangecontrib/single_cell/widgets/owloaddata.py
@@ -97,8 +97,9 @@ class RunaroundSettingsHandler(settings.SettingsHandler):
 
 
 class OWLoadData(widget.OWWidget):
-    name = ""
+    name = "Load Data"
     icon = "icons/LoadData.svg"
+    priority = 110
 
     class Outputs:
         data = widget.Output("Data", Table)

--- a/orangecontrib/single_cell/widgets/owlouvainclustering.py
+++ b/orangecontrib/single_cell/widgets/owlouvainclustering.py
@@ -137,7 +137,7 @@ class OWLouvainClustering(widget.OWWidget):
     name = 'Louvain Clustering'
     description = 'Detects communities in a network of nearest neighbours.'
     icon = 'icons/LouvainClustering.svg'
-    priority = 2150
+    priority = 910
 
     want_main_area = False
 

--- a/orangecontrib/single_cell/widgets/owmarkergenes.py
+++ b/orangecontrib/single_cell/widgets/owmarkergenes.py
@@ -116,7 +116,7 @@ class MarkerGroupContextHandler(settings.ContextHandler):
 class OWMarkerGenes(widget.OWWidget):
     name = "Marker Genes"
     icon = 'icons/MarkerGenes.svg'
-    priority = 158
+    priority = 170
 
     URL = "https://docs.google.com/spreadsheets/d/1ik-Ju5F-" \
           "wcsFhjszM7pRZXTTfSJl_EQOn3uNIzYfAY4/edit#gid=0"

--- a/orangecontrib/single_cell/widgets/owscorecells.py
+++ b/orangecontrib/single_cell/widgets/owscorecells.py
@@ -27,7 +27,7 @@ class OWScoreCells(widget.OWWidget):
     name = "Score Cells"
     description = "Add a cell score based on the given set of genes"
     icon = "icons/ScoreCells.svg"
-    priority = 180
+    priority = 320
 
     auto_apply = Setting(True)
     aggregation = Setting('Mean expression')

--- a/orangecontrib/single_cell/widgets/owscoregenes.py
+++ b/orangecontrib/single_cell/widgets/owscoregenes.py
@@ -266,7 +266,7 @@ class OWRank(OWWidget):
     name = "Score Genes"
     description = "Score and filter genes by their relevance."
     icon = "icons/ScoreGenes.svg"
-    priority = 170
+    priority = 310
 
     buttons_area_orientation = Qt.Vertical
 

--- a/orangecontrib/single_cell/widgets/owscpreprocess.py
+++ b/orangecontrib/single_cell/widgets/owscpreprocess.py
@@ -444,7 +444,7 @@ class OWscPreprocess(Orange.widgets.data.owpreprocess.OWPreprocess):
     name = "Single Cell Preprocess"
     description = "Preprocess Single Cell data set"
     icon = "icons/SingleCellPreprocess.svg"
-    priority = 160
+    priority = 220
 
     class Inputs:
         data = Input("Data", Orange.data.Table)

--- a/orangecontrib/single_cell/widgets/owtsne.py
+++ b/orangecontrib/single_cell/widgets/owtsne.py
@@ -138,7 +138,7 @@ class OWtSNE(OWWidget):
     name = "t-SNE"
     description = "Two-dimensional data projection with t-SNE."
     icon = "icons/TSNE.svg"
-    priority = 3055
+    priority = 920
 
     class Inputs:
         data = Input("Data", Orange.data.Table, default=True)


### PR DESCRIPTION
Redefines the order of the widgets in single cell add-on:

110 Load Data
150 Single Cell Data Sets
170 Marker Genes

210 Filter
220 Single Cell Preprocess
230	Batch Effect Removal
240 Align Datasets

310 Score Genes
320 Score Cells

410 Dot Matrix

910 Louvain Clustering
920 t-SNE