### PR TITLE
Load Data: Revert name change

### DIFF
--- a/orangecontrib/single_cell/widgets/owloaddata.py
+++ b/orangecontrib/single_cell/widgets/owloaddata.py
@@ -97,7 +97,7 @@ class RunaroundSettingsHandler(settings.SettingsHandler):
 
 
 class OWLoadData(widget.OWWidget):
-    name = "Load Data"
+    name = ""
     icon = "icons/LoadData.svg"
     priority = 110
 

--- a/orangecontrib/single_cell/widgets/owmultisample.py
+++ b/orangecontrib/single_cell/widgets/owmultisample.py
@@ -131,7 +131,7 @@ class OWMultiSample(owloaddata.OWLoadData):
     name = "Load Data"
     description = "Load samples for multi-sample analysis"
     icon = "icons/LoadData.svg"
-    priority = 155
+    priority = 110
 
     class Information(owloaddata.OWLoadData.Information):
         file_in_list = Msg("File {} already in the list.")


### PR DESCRIPTION
Load Data widget is now incorporated inside OWMultiSample so the priority change should be made there. OWLoadData should have an empty name to avoid both being visible.