### PR TITLE
CCA: Add sparse support

### DIFF
--- a/orangecontrib/single_cell/preprocess/cca.py
+++ b/orangecontrib/single_cell/preprocess/cca.py
@@ -1,12 +1,14 @@
-import numpy as np
 import itertools as it
-from sklearn.decomposition.truncated_svd import TruncatedSVD
+import numpy as np
 from scipy.stats import pearsonr
+from sklearn.decomposition.truncated_svd import TruncatedSVD
+
+import Orange.statistics.util as ut
 
 
 def _standardize(X, tol=1e-8):
     """ Standardize matrix X avoiding NaNs and small values. """
-    s = X.std(axis=0)
+    s = ut.std(X, axis=0)
     m = np.zeros(*s.shape)
     valid = s > tol
     m[np.logical_not(valid)] = 0


### PR DESCRIPTION
##### Issue
CCA did not support sparse matrices.


##### Description of changes
The only problematic part was that scipy doesn't have any direct way of computing standard deviation. This can easily be fixed through our `statistics.utils` module.

Depends on https://github.com/biolab/orange3/pull/3218.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
