### PR TITLE
tSNE: Update to use new implementation

### DIFF
--- a/orangecontrib/single_cell/widgets/owtsne.py
+++ b/orangecontrib/single_cell/widgets/owtsne.py
@@ -1,13 +1,11 @@
 import os.path
-import re
 import sys
 
 import numpy as np
-from joblib.memory import Memory
-
-from AnyQt.QtWidgets import QFormLayout, QApplication
-from AnyQt.QtGui import QPainter
 from AnyQt.QtCore import Qt, QTimer
+from AnyQt.QtGui import QPainter
+from AnyQt.QtWidgets import QFormLayout, QApplication
+from joblib.memory import Memory
 
 try:
     from MulticoreTSNE import MulticoreTSNE
@@ -27,7 +25,9 @@ from Orange.canvas import report
 from Orange.widgets.visualize.owscatterplotgraph import OWScatterPlotGraph, InteractiveViewBox
 from Orange.widgets.widget import Msg, OWWidget, Input, Output
 from Orange.widgets.utils.annotated_data import (
-    create_annotated_table, create_groups_table, ANNOTATED_DATA_SIGNAL_NAME)
+    create_annotated_table, create_groups_table, ANNOTATED_DATA_SIGNAL_NAME,
+    get_unique_names,
+)
 
 
 RE_FIND_INDEX = r"(^{} \()(\d{{1,}})(\)$)"
@@ -35,39 +35,6 @@ RE_FIND_INDEX = r"(^{} \()(\d{{1,}})(\)$)"
 tsne_cache = os.path.join(cache_dir(), "tsne")
 memory = Memory(tsne_cache, verbose=0, bytes_limit=1e8)
 memory.reduce_size()
-
-
-###
-### TODO: When the next two functions are released in Orange, import from there
-
-def get_indices(names, name):
-    """
-    Return list of indices which occur in a names list for a given name.
-    :param names: list of strings
-    :param name: str
-    :return: list of indices
-    """
-    return [int(a.group(2)) for x in names
-            for a in re.finditer(RE_FIND_INDEX.format(name), x)]
-
-
-def get_unique_names(names, proposed):
-    """
-    Returns unique names of variables. Variables which are duplicate get appended by
-    unique index which is the same in all proposed variable names in a list.
-    :param names: list of strings
-    :param proposed: list of strings
-    :return: list of strings
-    """
-    if len([name for name in proposed if name in names]):
-        max_index = max([max(get_indices(names, name),
-                             default=1) for name in proposed], default=1)
-        for i, name in enumerate(proposed):
-            proposed[i] = "{} ({})".format(name, max_index + 1)
-    return proposed
-
-###
-###
 
 
 @memory.cache

--- a/orangecontrib/single_cell/widgets/owtsne.py
+++ b/orangecontrib/single_cell/widgets/owtsne.py
@@ -30,8 +30,6 @@ from Orange.widgets.utils.annotated_data import (
 )
 
 
-RE_FIND_INDEX = r"(^{} \()(\d{{1,}})(\)$)"
-
 tsne_cache = os.path.join(cache_dir(), "tsne")
 memory = Memory(tsne_cache, verbose=0, bytes_limit=1e8)
 memory.reduce_size()


### PR DESCRIPTION
##### Issue
Once https://github.com/biolab/orange3/pull/3192 is merged, the tSNE widget here will no longer work due to the API change.

Should not be merged until https://github.com/biolab/orange3/pull/3192.

##### Description of changes
tSNE widget now works. I've removed the MulticoreTSNE code as well since the current implementation also implements Barnes-hut and is about as fast as MulticoreTSNE.

I've set the step size to 50 (chosen for no reason in particular), so the visualization is updated every 50 iterations. This is primarily done so the optimization can be stopped in between, otherwise one would have to wait until all iterations finished before the widget became responsive again.

One thing to note is the early exaggeration phase. The previous version was limited in the sense that the number of early exaggeration iterations was hardcoded to be 250 (in sklearn and MulticoreTSNE themselves). The early exaggeration factor was 1, so it behaved like the regular optimization. However, this mean that we could not optmimize for any less than 250 steps. With the new implementation, there is no such limitation, so we can actually run a single iteration if we want. Both the previous and current implementation completely remove the early exaggeration phase. This is generally not a good idea and can lead to worse visualizations. The point of early exaggeration is to correct poor initializations and clump similar points together.

I've set the optimization scheme to automatically switch to FFT interpolation when the number of points exceeds 10k. This was arbitratily chosen and is likely not the best cutoff point for Barnes-Hut. However, I am certain that FFT is faster than BH at 10k points.

Also, I've removed the old code with the TODO to remove once merged into core. I am fairly certain that code has long since been merged into core.

Also, from what I could tell, the previous implementation always 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
