### PR TITLE
[WIP] Analysis of pseudotime trajectories 

### DIFF
--- a/orangecontrib/single_cell/preprocess/pseudotimemst.py
+++ b/orangecontrib/single_cell/preprocess/pseudotimemst.py
@@ -1,0 +1,204 @@
+from math import ceil
+import random
+
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.colors as clr
+
+import Orange
+from Orange.distance import Euclidean
+
+
+def add_tuple(t1, t2):
+    return tuple(a+b for a,b in zip(t1,t2))
+
+def farthest(x, tab_centroids, adj, p=-1, d=0):
+    f = [farthest(z, tab_centroids, adj, d+dist(tab_centroids[x], tab_centroids[z])) for z in adj[x] if z!=p]
+    if f: return max(f)
+    else: return (d,x)
+
+
+def order(x, adjp, pseudotime, tab_centroids, proj, proj_sign, adj, p=-1, d=0):
+    for i in adjp[x]:
+        if pseudotime[i] is not None: continue
+        dxi = dist(tab_centroids[x], proj[i])
+        if p==-1 and proj_sign[i]==-1:
+            pseudotime[i] = d - dxi
+        else:
+            pseudotime[i] = d + dxi
+    for z in adj[x]:
+        if z==p: continue
+        order(z, x, d+dist(tab_centroids[x], tab_centroids[z]))
+    return pseudotime
+
+def dist(coord1, coord2):
+    return sum((x1-x2)**2 for x1, x2 in zip(coord1, coord2))**0.5
+
+
+def mst_prim(data, dist=Euclidean()):
+    n = len(data)
+    dist = dist.fit(data)
+    distance_to_tree = [float("inf") for i in range(n)]
+    neighbour_in_tree = [None for i in range(n)]
+    added = [False for i in range(n)]
+    edges = []
+    for r in range(n):  # repeat n times (add a new node each time)
+        # find the node closest to the tree
+        a = -1
+        for i in range(n):
+            if not added[i] and (a == -1 or distance_to_tree[i] < distance_to_tree[a]):
+                a = i
+        # add node a to the tree
+        if neighbour_in_tree[a] is not None:
+            edges.append((a, neighbour_in_tree[a]))
+        added[a] = True
+        # update distances of nodes to tree
+        distance_a = dist(data[a], data)[0]  # distance function
+        for i in range(n):
+            if not added[i] and distance_a[i] < distance_to_tree[i]:
+                distance_to_tree[i] = distance_a[i]
+                neighbour_in_tree[i] = a
+
+    return edges
+
+
+class Pseudotimemst:
+
+    def __init__(self, n_components=2, n_clusters=5,
+                 projection=Orange.projection.PCA, clustering=Orange.clustering.KMeans): # can add projection, clustering alg
+        self.ncomp = n_components
+        self.data = None
+        self.transformed_data = None
+        self.nclust = n_clusters
+        self.projection = projection
+        self.clustering = clustering
+        self.clustering_model = None
+        self.pseudotime = None
+        self.proj = None
+
+    def fit_transform(self, data):
+        self.data = data
+        # transform
+        projection_obj = self.projection(n_components=self.ncomp)
+        self.transformed_data = projection_obj(self.data)(self.data)
+
+        # cluster
+        if self.nclust is None:
+            self.nclust = ceil(0.05*len(self.transformed_data))
+        clustering_model = self.clustering(n_clusters=self.nclust)(self.transformed_data)
+        self.clustering_model = clustering_model
+
+        self.clusters = [[] for _ in range(clustering_model.k)]
+        for i, c in enumerate(clustering_model.labels_):
+            self.clusters[c].append(i)
+
+        # minimum spanning tree
+        edges = mst_prim(Orange.data.Table.from_numpy(None, clustering_model.centroids))
+        adj = [[] for _ in range(clustering_model.k)]
+        for a,b in edges:
+            adj[a].append(b)
+            adj[b].append(a)
+        mst_coordinates = [[clustering_model.centroids[a], clustering_model.centroids[b]] for a,b in edges]
+        self.mst_coordinates = mst_coordinates
+
+        # project
+        proj = np.zeros((len(self.data), self.ncomp))
+        proj_sign = [1 for _ in range(len(self.data))]
+        adjp = [[] for _ in range(clustering_model.k)]
+
+        tab_centroids = Orange.data.Table.from_numpy(None, clustering_model.centroids)
+        for c in range(clustering_model.k):  # for every cluster
+            for i in self.clusters[c]:  # for each instance in cluster c
+                # find nearest adjacent cluster c2 (second nearest cluster)
+                c2 = min(adj[c], key=lambda c2: dist(self.transformed_data[i].x, clustering_model.centroids[c2]))
+                # project instance i onto edge (c, c2)
+                vi = [self.transformed_data[i][d] - tab_centroids[c][d] for d in range(self.ncomp)]
+                v = [tab_centroids[c2][d] - tab_centroids[c][d] for d in range(self.ncomp)]
+                a = np.dot(vi, v) / np.dot(v, v)
+                proj_sign[i] = 1
+                if a < 0:
+                    if len(adj[c]) > 1:
+                        a = 0
+                    else:
+                        proj_sign[i] = -1
+                if a > 1: a = 1
+                proj[i] = [tab_centroids[c][d] + a * v[d] for d in range(self.ncomp)]
+                adjp[c].append(i)
+                adjp[c2].append(i)
+        self.proj = proj
+
+        def farthest(x, p=-1, d=0):
+            f = [farthest(z, x, d + dist(tab_centroids[x], tab_centroids[z])) for z in adj[x] if
+                 z != p]
+            if f:
+                return max(f)
+            else:
+                return (d, x)
+
+        def order(x, p=-1, d=0):
+            for i in adjp[x]:
+                if pseudotime[i] is not None: continue
+                dxi = dist(tab_centroids[x], proj[i])
+                if p == -1 and proj_sign[i] == -1:
+                    pseudotime[i] = d - dxi
+                else:
+                    pseudotime[i] = d + dxi
+            for z in adj[x]:
+                if z == p: continue
+                order(z, x, d + dist(tab_centroids[x], tab_centroids[z]))
+
+        start = farthest(0)[1]
+        pseudotime = [None for i in range(len(self.transformed_data))]
+        order(start)
+        ptm, ptM = min(pseudotime), max(pseudotime)
+        pseudotime = np.array([(pt - ptm) / (ptM - ptm) for pt in pseudotime])
+        self.pseudotime = pseudotime
+
+    def visualize(self):
+        import matplotlib.pyplot as plt
+        import matplotlib.colors as clr
+
+        ax = plt.axes()
+        ax.set_aspect('equal')
+        ax.set_adjustable('box')
+        for a, b in self.mst_coordinates:
+            ax.plot([a[0], b[0]], [a[1], b[1]], c="black")
+
+        x = self.clustering_model.centroids[:, 0]
+        y = self.clustering_model.centroids[:, 1]
+        ax.scatter(x, y, s=10, c="black", marker='x')
+
+        x = np.array([row[0] for row in self.transformed_data])
+        y = np.array([row[1] for row in self.transformed_data])
+        l = np.array([str(row.get_class()) for row in self.transformed_data])
+
+        colors = list(clr.CSS4_COLORS)
+        random.seed(1234)
+        random.shuffle(colors)
+
+        labels = sorted(set(l))
+        for i, label in enumerate(labels):
+            mask = (l == label)
+            ax.scatter(x[mask], y[mask], s=5, color=colors[i], label=label)
+
+        for i in range(len(self.transformed_data)):
+            ax.annotate("%.2f" % self.pseudotime[i], (x[i], y[i]), fontsize=7)
+
+        ax.legend(bbox_to_anchor=(1.05, 1), loc="upper left", markerscale=3)
+        ax.autoscale()
+
+        # projection lines
+        for i in range(len(self.transformed_data)):
+            ax.plot([x[i], self.proj[i][0]], [y[i], self.proj[i][1]], linewidth=1, color='lightgray')
+
+        plt.tight_layout()
+        plt.show()
+
+
+if __name__ == '__main__':
+    pmst = Pseudotimemst()
+
+    tab = Orange.data.Table("brown-selected")
+
+    pmst.fit_transform(tab)
+    pmst.visualize()

--- a/orangecontrib/single_cell/widgets/owtrajectory.py
+++ b/orangecontrib/single_cell/widgets/owtrajectory.py
@@ -1,0 +1,334 @@
+from itertools import chain
+from xml.sax.saxutils import escape
+
+import numpy as np
+from scipy.stats import linregress
+from sklearn.neighbors import NearestNeighbors
+from sklearn.metrics import r2_score
+
+from AnyQt.QtCore import Qt, QTimer, QPointF, QLineF
+from AnyQt.QtGui import QColor, QPainterPath
+from AnyQt.QtWidgets import QApplication, QFormLayout, QGraphicsPathItem, QGraphicsLineItem
+
+import pyqtgraph as pg
+
+import Orange
+from Orange.data import Table, Domain, ContinuousVariable, DiscreteVariable
+from Orange.data.sql.table import SqlTable, AUTO_DL_LIMIT
+from Orange.preprocess.score import ReliefF, RReliefF
+
+from Orange.widgets import gui, report, widget
+from Orange.widgets.settings import (
+    DomainContextHandler, Setting, ContextSetting, SettingProvider
+)
+from Orange.widgets.utils import get_variable_values_sorted
+from Orange.widgets.utils.annotated_data import (
+    create_annotated_table, create_groups_table, ANNOTATED_DATA_SIGNAL_NAME
+)
+from Orange.widgets.utils.itemmodels import DomainModel
+from Orange.widgets.visualize.owscatterplotgraph import (
+    OWScatterPlotGraph, OWScatterPlotBase, OWProjectionWidget
+)
+from Orange.widgets.visualize.utils.plotutils import AnchorItem
+from Orange.widgets.visualize.utils import VizRankDialogAttrPair
+from Orange.widgets.widget import AttributeList, Msg, Input, Output
+
+from orangecontrib.single_cell.preprocess.pseudotimemst import Pseudotimemst
+
+MAX_COMPONENTS = 20
+MAX_CLUSTERS = 20
+DIM_REDUCTIONS = [
+    ("PCA", Orange.projection.PCA),
+    #("UMAP", Orange.projection.UMAP),
+]
+
+class OWPseudotimeGraph(OWScatterPlotBase):
+    jitter_size = Setting(0)
+    jitter_continuous = Setting(False)
+
+    def __init__(self, scatter_widget, parent):
+        super().__init__(scatter_widget, parent)
+        self.reg_line_item = None
+        self.mst_coord = None
+        self.proj_lines = None
+
+    def get_mst(self):
+        self.mst_coord = self.master.get_mst_data()
+        return self.mst_coord
+
+    def update_mst(self):
+        pen = pg.mkPen(QColor(Qt.black), width=1, cosmetic=True)
+        self._mst = self.get_mst()
+        for a, b in self._mst:
+            self._mst_line = QGraphicsLineItem()
+            self._mst_line.setLine(a[0],a[1],b[0],b[1])
+            self._mst_line.setPen(pen)
+            self.plot_widget.addItem(self._mst_line)
+
+    def get_proj_lines(self):
+        dest, [x, y] = self.master.get_proj_lines_data()
+        res = list()
+        for i in range(len(dest)):
+            res.append([dest[i], [x[i], y[i]]])
+        return res
+
+    def update_proj_lines(self):
+        pen = pg.mkPen(QColor(Qt.black), width=.5, cosmetic=True)
+        proj_lines = self.get_proj_lines()
+
+        for a, b in proj_lines:
+            self._mst_line = QGraphicsLineItem()
+            self._mst_line.setLine(a[0], a[1], b[0], b[1])
+            self._mst_line.setPen(pen)
+            self.plot_widget.addItem(self._mst_line)
+
+    def reset_graph(self):
+        super().reset_graph()
+        self.update_mst()
+        self.update_proj_lines()
+
+    def clear(self):
+        super().clear()
+        self.reg_line_item = None
+        self.mst_coord = None
+        self.proj_lines = None
+
+    def set_axis_labels(self, axis, labels):
+        axis = self.plot_widget.getAxis(axis)
+        if labels:
+            axis.setTicks([list(enumerate(labels))])
+        else:
+            axis.setTicks(None)
+
+    def set_axis_title(self, axis, title):
+        self.plot_widget.setLabel(axis=axis, text=title)
+
+    def update_coordinates(self):
+        super().update_coordinates()
+
+
+
+class OWTrajectory(OWProjectionWidget):
+    name = "Trajectory"
+    description = "Placeholder"
+    icon = "icons/Trajectory.svg"
+    priority = 1000
+
+    class Inputs:
+        data = Input("Data", Orange.data.Table, default=True)
+        data_subset = Input("Data Subset", Orange.data.Table)
+
+    class Outputs:
+        pseudotimes = Output("Pseudotimes for Cells", Orange.data.Table, default=True)
+
+    settingsHandler = DomainContextHandler()
+
+    auto_send_selection = Setting(True)
+    auto_sample = Setting(True)
+    tooltip_shows_all = Setting(True)
+
+    n_components = Setting(2)
+    n_clusters = Setting(10)
+    dim_reduction = Setting("PCA")
+
+
+    graph = SettingProvider(OWPseudotimeGraph)
+    graph_name = "graph.plot_widget.plotItem"
+
+    class Warning(widget.OWWidget.Warning):
+        placeholder = Msg("Placeholder warning")
+
+    class Information(widget.OWWidget.Information):
+        missing_size = Msg(
+            "Points with undefined '{}' are shown in smaller size")
+        missing_shape = Msg(
+            "Points with undefined '{}' are shown as crossed circles")
+
+
+    def __init__(self):
+        super().__init__()
+
+        box = gui.vBox(self.mainArea, True, margin=0)
+        self.graph = OWPseudotimeGraph(self, box)
+        box.layout().addWidget(self.graph.plot_widget)
+
+        self.subset_data = None
+        self.subset_indices = None
+        self.sql_data = None
+        self.xy = None
+        #self.data = None  # neaded?
+        self.__timer = QTimer(self, interval=1200)
+        self.__timer.timeout.connect(self.add_data)
+
+        common_options = dict(
+            labelWidth=50, orientation=Qt.Horizontal, sendSelectedValue=True,
+            valueType=str, contentsLength=14
+        )
+
+        box = gui.vBox(self.controlArea, "Controls")
+        dmod = DomainModel
+        self.dom_model = DomainModel(dmod.MIXED, valid_types=dmod.PRIMITIVE)
+
+        form = QFormLayout()
+
+        gui.comboBox(
+            box, self, "dim_reduction",
+            callback=self.attr_changed,
+            editable=False,
+            items=[item for item, _ in DIM_REDUCTIONS],
+            sendSelectedValue=True
+        )
+        gui.spin(
+            box, self, "n_components", 2, MAX_COMPONENTS,
+            callback=self.attr_changed,
+            keyboardTracking=False,
+        )
+
+        gui.spin(
+            box, self, "n_clusters", 2, MAX_CLUSTERS,
+            callback=self.attr_changed,
+            keyboardTracking=False,
+        )
+        form.addRow("Dimensionality reduction:", self.controls.dim_reduction)
+        form.addRow("Num. of components:", self.controls.n_components)
+        form.addRow("Num. of clusters:", self.controls.n_clusters)
+        box.layout().addLayout(form)
+
+        g = self.graph.gui
+
+        g.point_properties_box(self.controlArea)
+
+        box = g.create_gridbox(self.controlArea, True)
+        g.add_widgets([
+            g.PointSize,
+            g.AlphaValue,
+            #g.JitterSizeSlider,
+            ], box
+        )
+        #g.add_widget(g.JitterNumericValues, box)
+
+        box_plot_prop = g.plot_properties_box(self.controlArea)
+        g.add_widgets([
+            g.ShowGridLines,
+            g.ToolTipShowsAll],
+            box_plot_prop)
+
+        self.controlArea.layout().addStretch(100)
+        self.graph.box_zoom_select(self.controlArea)
+        gui.auto_commit(self.controlArea, self, "auto_send_selection",
+                        "Send Selection", "Send Automatically")
+
+    @Inputs.data
+    def set_data(self, data):
+        #self.Information.sampled_sql.clear()
+
+        if isinstance(data, SqlTable):
+            if data.approx_len() < 5000:
+                data = Table(data)
+            else:
+                self.Information.sampled_sql()
+                self.sql_data = data
+                data_sample = data.sample_time(0.8, no_cache=True)
+                data_sample.download_data(2000, partial=True)
+                data = Table(data_sample)
+                self.sampling.setVisible(True)
+                if self.auto_sample:
+                    self.__timer.start()
+
+        if data is not None and (len(data) == 0 or len(data.domain) == 0):
+            data = None
+        if self.data and data and self.data.checksum() == data.checksum():
+            return
+        self.closeContext()
+        same_domain = (self.data and data and
+                       data.domain.checksum() == self.data.domain.checksum())
+        self.data = data
+
+        if not same_domain:
+            self.init_attr_values()
+        self.openContext(self.data)
+        self.attr_changed()
+
+
+    def fit_transform(self):
+        if self.data is None:
+            return
+        p = Pseudotimemst(n_components=self.n_components, n_clusters=self.n_clusters,
+                          projection=[ext for name, ext in DIM_REDUCTIONS if name == self.dim_reduction][0])
+        p.fit_transform(self.data)
+        self.p = p
+        self.xy = [np.array([row[0] for row in p.transformed_data]), np.array([row[1] for row in p.transformed_data])]
+
+    def attr_changed(self):
+        self.fit_transform()
+        self.graph.reset_graph()
+        self.commit()
+
+        for axis, var in (("bottom", "PCA component1"), ("left", "PCA component 2")):
+            self.graph.set_axis_title(axis, None)
+            self.graph.set_axis_labels(axis, None)
+
+
+    def get_mst_data(self):
+        return self.p.mst_coordinates
+
+    def get_proj_lines_data(self):
+        return self.p.proj, self.xy
+
+    def get_coordinates_data(self):
+        return self.xy[0], self.xy[1]
+
+    @Inputs.data_subset
+    def set_subset_data(self, subset_data):
+        self.warning()
+        pass
+
+    def add_data(self, time=0.4):
+        if self.data and len(self.data) > 2000:
+            return self.__timer.stop()
+        data_sample = self.sql_data.sample_time(time, no_cache=True)
+        if data_sample:
+            data_sample.download_data(2000, partial=True)
+            data = Table(data_sample)
+            self.data = Table.concatenate((self.data, data), axis=0)
+            self.handleNewSignals()
+
+
+    def handle_new_signals(self):
+        if self.data is None:
+            return
+        self.attr_changed()
+        self.graph.set_
+        self.cb_class_density.setEnabled(self.can_draw_density())
+        self.commit()
+
+
+    def send_pseudotimes(self):
+        pt = self.p.pseudotime
+        table = Table.from_numpy(
+            Domain(
+                [ContinuousVariable.make("pseudotime")],
+                self.data.domain.class_vars,
+                self.data.domain.metas
+            ),
+            np.array([pt]).T,
+            self.data.Y,
+            self.data.metas
+        )
+        self.Outputs.pseudotimes.send(table)
+
+    def commit(self):
+        self.send_pseudotimes()
+
+
+if __name__ == '__main__':
+    a = QApplication([])
+
+    ow = OWTrajectory()
+
+    tab = Orange.data.Table("brown-selected")
+    ow.set_data(tab)
+    ow.show()
+    ow.raise_()
+
+    rval = a.exec()


### PR DESCRIPTION
##### Issue
Prototype of a widget based on a code in biolab/orange3-prototypes#148.

##### Description of changes
Current looks is based on scatter plot and implements same basic functionalities and drawn graph is similar to the prototypes:
![image](https://user-images.githubusercontent.com/17678055/46671486-386de980-cbd5-11e8-8e71-77d2b5f719c9.png)
Supports selection of number of components, clusters and choosing of dimensionality reduction (currently only PCA). 
Allows showing/hiding pseudotime labels and drawing/hiding projection lines.
Currently the only output of a widget is pseudotime for all/selected points/rows.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
