### PR TITLE
[FIX] ContingencyTable: Fix for labels getting cut off in circle mode

### DIFF
--- a/orangecontrib/single_cell/widgets/contingency_table.py
+++ b/orangecontrib/single_cell/widgets/contingency_table.py
@@ -126,7 +126,6 @@ class ContingencyTable(QTableView):
         self.headerh = None
         self.cleared = True
         self.parent = parent
-        self.default_cell_width = None
 
         self.corner_string = unicodedata.lookup("N-ARY SUMMATION")
 
@@ -289,9 +288,10 @@ class ContingencyTable(QTableView):
         """
         if self.circles:
             self.verticalHeader().setDefaultSectionSize(self.cell_size)
-            if self.default_cell_width is None:
-                self.default_cell_width = self.horizontalHeader().defaultSectionSize()
-            self.horizontalHeader().setDefaultSectionSize(self.default_cell_width)
+            # If the following line is removed, VerticalItemDelegate.sizeHint()
+            # of the headers returns sizes which are too short and the
+            # headers are cut off.
+            self.horizontalHeader().setDefaultSectionSize(100)
             self.resizeRowToContents(1)
             self.horizontalHeader().setDefaultSectionSize(self.cell_size)
             self.resizeColumnToContents(1)

--- a/orangecontrib/single_cell/widgets/contingency_table.py
+++ b/orangecontrib/single_cell/widgets/contingency_table.py
@@ -126,6 +126,7 @@ class ContingencyTable(QTableView):
         self.headerh = None
         self.cleared = True
         self.parent = parent
+        self.default_cell_width = None
 
         self.corner_string = unicodedata.lookup("N-ARY SUMMATION")
 
@@ -288,8 +289,11 @@ class ContingencyTable(QTableView):
         """
         if self.circles:
             self.verticalHeader().setDefaultSectionSize(self.cell_size)
+            if self.default_cell_width is None:
+                self.default_cell_width = self.horizontalHeader().defaultSectionSize()
+            self.horizontalHeader().setDefaultSectionSize(self.default_cell_width)
             self.resizeRowToContents(1)
-            self.horizontalHeader().setDefaultSectionSize(self.rowHeight(2))
+            self.horizontalHeader().setDefaultSectionSize(self.cell_size)
             self.resizeColumnToContents(1)
             self.tablemodel.setRowCount(len(self.classesv) + 2)
             self.tablemodel.setColumnCount(len(self.classesh) + 2)


### PR DESCRIPTION
##### Issue
Fixes #303 

##### Description of changes
This solution here is quite ugly. I don't know how to fix this properly.

If we input the iris dataset, the longest of the labels at the top has a size hint of (29, 98) after calling `self.resizeRowToContents(1)`. But if `self.horizontalHeader().setDefaultSectionSize(self.cell_size)` is called before that (the problem can occur at the next call of this method) with value 30, the size hint will be (46, 73). The other two labels have shorter and wider size hints as well. The delegate used is `CircleItemDelegate`, which uses methods from `gui.VerticalItemDelegate` for those labels.

The current fix stores the default `self.horizontalHeader().defaultSectionSize()`, which seems to be 100, and applies it before the call to `self.resizeRowToContents(1)`. After that it sets the value again to `self.cell_size`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
