### PR TITLE
[FIX] TestSelectMostVariableGene: fix failing test

### DIFF
--- a/orangecontrib/single_cell/tests/preprocess/test_scpreprocess.py
+++ b/orangecontrib/single_cell/tests/preprocess/test_scpreprocess.py
@@ -117,7 +117,7 @@ class TestSelectMostVariableGenes(unittest.TestCase):
         pp_table = SelectMostVariableGenes(n_genes=2, n_groups=2)(table)
         self.assertIsInstance(pp_table, Table)
         self.assertNotEqual(pp_table, table)
-        npt.assert_array_equal(pp_table, table[:, [0, 2]])
+        npt.assert_array_equal(pp_table, table[:, :2])
 
     def test_options_dispersion(self):
         attrs, cls = self.data.domain.attributes, self.data.domain.class_vars


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Test failed with new version of scipy (1.1.0), because bin limits are treated differently.

##### Description of changes


##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
