### PR TITLE
[FIX] OWDotMatrix: Removing reports and report button

### DIFF
--- a/orangecontrib/single_cell/widgets/owdotmatrix.py
+++ b/orangecontrib/single_cell/widgets/owdotmatrix.py
@@ -240,21 +240,6 @@ class OWDotMatrix(widget.OWWidget):
         self.selection = self.tableview.get_selection()
         self.commit()
 
-    def send_report(self):
-        rows = None
-        columns = None
-        if self.data is not None:
-            rows = self.cluster_var
-            if rows in self.data.domain:
-                rows = self.data.domain[rows]
-            columns = self.columns
-            if columns in self.data.domain:
-                columns = self.data.domain[columns]
-        self.report_items((
-            ("Rows", rows),
-            ("Columns", columns),
-        ))
-
 
 def test():
     from AnyQt.QtWidgets import QApplication


### PR DESCRIPTION
##### Issue
Fixes #308 

##### Description of changes
Removed the entire `send_report` function which also removes the report button. The function never did anything useful and was just copied from another widget.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
