### PR TITLE
t-SNE: Switch to approximat NN search when have large number of samples

### DIFF
--- a/orangecontrib/single_cell/widgets/owtsne.py
+++ b/orangecontrib/single_cell/widgets/owtsne.py
@@ -38,9 +38,11 @@ memory.reduce_size()
 @memory.cache
 def compute_tsne_embedding(X, perplexity, iter, init):
     negative_gradient_method = 'fft' if len(X) > 10000 else 'bh'
+    neighbor_method = 'approx' if len(X) > 10000 else 'exact'
     tsne = Orange.projection.TSNE(
         perplexity=perplexity, n_iter=iter, initialization=init, theta=.8,
-        early_exaggeration_iter=0, negative_gradient_method=negative_gradient_method
+        early_exaggeration_iter=0, negative_gradient_method=negative_gradient_method,
+        neighbors=neighbor_method,
     )
     tsne_model = tsne.fit(X)
     return np.asarray(tsne_model, dtype=np.float32)


### PR DESCRIPTION
##### Issue
When dealing with larger data sets, approximate nearest neighbors scales better than exact search.


##### Description of changes
Switch to approx NN search when the number of samples exceeds 10000, like the gradient method.

@VesnaT This should be included, otherwise t-SNE may be unusable for larger data sets.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
