### PR TITLE
Switch index url for Single Cell Datasets widget.

### DIFF
--- a/orangecontrib/single_cell/widgets/owscdatasets.py
+++ b/orangecontrib/single_cell/widgets/owscdatasets.py
@@ -20,7 +20,7 @@ class OWscDataSets(Orange.widgets.data.owdatasets.OWDataSets):
     icon = "icons/SingleCellDatasets.svg"
     priority = 150
 
-    INDEX_URL = "http://datasets.orange.biolab.si/sc/"
+    INDEX_URL = "https://datasets.biolab.si/sc/"
     DATASET_DIR = "sc-datasets"
 
     HEADER_SCHEMA = [


### PR DESCRIPTION
We have added support for HTTPS on domain datasets.biolab.si. Certificates are auto-renewed by Cloudflare, no more letsencrypt scripts. The datasets can be cached on Cloudflare.

This PR relies on: https://github.com/biolab/orange3/pull/3412

##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->


##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
