### PR TITLE
[FIX] OWDotMatrix: Fixed errors which occur when no discrete variables

### DIFF
--- a/orangecontrib/single_cell/widgets/owdotmatrix.py
+++ b/orangecontrib/single_cell/widgets/owdotmatrix.py
@@ -130,14 +130,18 @@ class OWDotMatrix(widget.OWWidget):
         if self.data:
             self.feature_model.set_domain(self.data.domain)
             if self.feature_model:
+                self.Error.clear()
                 self.openContext(self.data)
                 if self.cluster_var is None:
                     self.cluster_var = self.feature_model[0]
                 self._calculate_table_values()
             else:
                 self.tableview.clear()
+                self.error("No discrete variables in data.")
+                self.data = None
         else:
             self.tableview.clear()
+            self.Error.clear()
 
     @staticmethod
     def _group_by(table: Table, var: DiscreteVariable):
@@ -246,7 +250,7 @@ def test():
     app = QApplication([])
 
     w = OWDotMatrix()
-    data = Table("iris")
+    data = Table("housing")
     w.set_data(data)
     w.handleNewSignals()
     w.show()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
#309 

##### Description of changes
There was an error when user tried to change aggregation and there were no discrete variables in data. Now user is warned that there is no discrete variable and the widget acts as if there is no data on input.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
