### PR TITLE
 ExcelLoader: Speedup and enhancement

### DIFF
--- a/orangecontrib/single_cell/tests/test_load_data.py
+++ b/orangecontrib/single_cell/tests/test_load_data.py
@@ -75,7 +75,7 @@ class TestLoadData(unittest.TestCase):
         file_name = os.path.join(os.path.dirname(__file__), "data/data.xlsx")
         loader = ExcelLoader(file_name)
         self.assertEqual(loader.file_size, 9160)
-        self.assertEqual(loader.n_rows, 10)
+        self.assertEqual(loader.n_rows, 11)
         self.assertEqual(loader.n_cols, 15)
         self.assertEqual(round(loader.sparsity, 2), 0.86)
 

--- a/orangecontrib/single_cell/tests/test_owloaddata.py
+++ b/orangecontrib/single_cell/tests/test_owloaddata.py
@@ -47,7 +47,7 @@ class TestOWLoadData(WidgetTest):
         file_name = os.path.join(self._path, "data.xlsx")
         self.widget.set_current_path(file_name)
         text = self.widget.summary_label.text()
-        self.assertEqual(text, "8.9 KB, 10 rows, 15 columns")
+        self.assertEqual(text, "8.9 KB, 11 rows, 15 columns")
         self._check_headers_and_row_labels_box((1, True, 1, True))
         self._check_input_data_structure_box((True, True, False, True))
         self._check_sample_data_box()

--- a/orangecontrib/single_cell/widgets/load_data.py
+++ b/orangecontrib/single_cell/widgets/load_data.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import scipy.io
 import loompy as lp
+import xlrd
 
 from Orange.data import (
     ContinuousVariable, DiscreteVariable, StringVariable, Domain, Table
@@ -587,6 +588,15 @@ class PickleLoader(Loader):
 
 
 class ExcelLoader(Loader):
+    def _set_file_parameters(self):
+        try:
+            sheet = xlrd.open_workbook(self._file_name).sheet_by_index(0)
+            self.n_cols = sheet.ncols
+            self.n_rows = sheet.nrows
+            self._set_sparsity()
+        except Exception:
+            pass
+
     @staticmethod
     def df_read_func(*args, **kwargs):
         return pd.read_excel(*args, **kwargs)

--- a/orangecontrib/single_cell/widgets/load_data.py
+++ b/orangecontrib/single_cell/widgets/load_data.py
@@ -588,6 +588,11 @@ class PickleLoader(Loader):
 
 
 class ExcelLoader(Loader):
+    def __init__(self, file_name):
+        super().__init__(file_name)
+        self.header_rows_count = 1
+        self.header_cols_count = 1
+
     def _set_file_parameters(self):
         try:
             sheet = xlrd.open_workbook(self._file_name).sheet_by_index(0)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Load Data widget is slow when opening big excel files.
Beside that, most Excel files have at least one header row, so default number of header rows should be 1.

##### Description of changes
- xlrd is used (instead of pandas) to get number of rows and columns
- set default number of header rows and files to 1

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
