### PR TITLE
[FIX] Conda Installer: Restore compatibility with latest anaconda python

### DIFF
--- a/installer/windows/build-conda-installer.sh
+++ b/installer/windows/build-conda-installer.sh
@@ -361,8 +361,8 @@ else
     conda-fetch-packages "${BASEDIR:?}"/conda-pkgs "${ENV_SPEC_FILE}"
     # extract the orange version from env spec
     VERSION=$(cat < "${BASEDIR:?}"/conda-pkgs/conda-spec.txt |
-              grep -E 'orange3-single-cell.*tar.bz2' |
-              cut -d "-" -f 4)
+              grep -E 'orange3-singlecell.*tar.bz2' |
+              cut -d "-" -f 3)
 fi
 
 if [[ ! "${VERSION}" ]]; then

--- a/installer/windows/build-conda-installer.sh
+++ b/installer/windows/build-conda-installer.sh
@@ -375,4 +375,5 @@ cp "${CACHEDIR:?}/miniconda/Miniconda3-${MINICONDA_VERSION}-Windows-${CONDAPLATT
 
 mkdir -p "${BASEDIR:?}/icons"
 cp "$(dirname "$0")"/{scOrange.ico,OrangeOWS.ico} "${BASEDIR:?}/icons"
+cp "$(dirname "$0")"/sitecustomize.py "${BASEDIR:?}"/conda-pkgs
 make-installer

--- a/installer/windows/condainstall.bat
+++ b/installer/windows/condainstall.bat
@@ -52,3 +52,5 @@ if not exist "%ACTIVATE_BAT%" (
     echo @echo off >  "%ACTIVATE_BAT%"
     echo call "%CONDA_BASE_PREFIX%\Scripts\activate.bat" "%PREFIX%" >> "%ACTIVATE_BAT%"
 )
+
+copy sitecustomize.py "%PREFIX%\Lib\

--- a/installer/windows/sitecustomize.py
+++ b/installer/windows/sitecustomize.py
@@ -1,0 +1,27 @@
+#
+# sitecustomize added by orange single cell installer.
+#
+# (Ana)conda python distribution expects it is 'activated', it does not really
+# support unactivated invocations (although a similar facility to this was
+# included in anaconda python 3.6 and earlier).
+
+import sys
+import os
+
+
+def normalize(path):
+    return os.path.normcase(os.path.normpath(path))
+
+
+extra_paths = [
+    r"Library\bin",
+]
+
+paths = os.environ.get("PATH", "").split(os.path.pathsep)
+paths = [normalize(path) for path in paths]
+
+for path in extra_paths:
+    path = os.path.join(sys.prefix, path)
+
+    if os.path.isdir(path) and normalize(path) not in paths:
+        os.environ["PATH"] = os.pathsep.join((path, os.environ.get("PATH", "")))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Installed shortcuts, registry commands,... use installed anaconda python distribution without activation, but:

`conda install --prefix ./test python=3.7.3 numpy`
then without activating the test env
`.\test\python.exe -c "import numpy" fails with a `ImportErorr: DLL load failed...`

##### Description of changes

Do the equivalent of https://github.com/AnacondaRecipes/python-feedstock/commit/d6830a4afa9aed2ee296accdc6e3d2d3996074ce#diff-d4e4e88c0c4b6c1e582c1d0fa9543940
(which is no longer applied to latest anaconda python 3.7.3)

This does not fix the fact that we use conda in a way that runs counter to their design.
##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
