### PR TITLE
[FIX] owfilter: Clear the scene in onDeleteWidget

### DIFF
--- a/orangecontrib/single_cell/widgets/owfilter.py
+++ b/orangecontrib/single_cell/widgets/owfilter.py
@@ -766,6 +766,7 @@ class OWFilter(widget.OWWidget):
     def onDeleteWidget(self):
         self.clear()
         self._plot.close()
+        self._view.scene().clear()
         super().onDeleteWidget()
 
     @classmethod


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

[Fix an "AttributeError: 'NoneType' object has no attribute 'hide'"](https://travis-ci.org/biolab/orange3-single-cell/jobs/553635199#L1283)

##### Description of changes

Clear the scene in onDeleteWidget 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
