### PR TITLE
OWAlignDatasets: Set Source ID as a source ID parameter by default

### DIFF
--- a/orangecontrib/single_cell/widgets/owaligndatasets.py
+++ b/orangecontrib/single_cell/widgets/owaligndatasets.py
@@ -218,7 +218,9 @@ class OWAlignDatasets(widget.OWWidget):
         if self.data:
             self._feature_model.set_domain(self.data.domain)
             if self._feature_model:
-                # self.openContext(data)
+                # if source id is available we assume that it is the feature that describes a dataset source
+                if "Source ID" in self.data.domain:
+                    self.source_id = self.data.domain["Source ID"]
                 self.openContext(self.data.domain)
                 if self.source_id is None or self.source_id == '':
                     for model in self._feature_model:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The widget does not use a separate thread for computation. When data are connected to the widget it selects fist discrete attribute and uses it as a source ID. If it is an attribute with several different values computation takes long and freezes Orange.

##### Description of changes

If we find the `Source ID` variable in data we assume it is dataset source id, so we set it as a Source ID attribute.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
