### PR TITLE
Dropout: Speedup reploting

### DIFF
--- a/orangecontrib/single_cell/preprocess/scpreprocess.py
+++ b/orangecontrib/single_cell/preprocess/scpreprocess.py
@@ -190,7 +190,7 @@ class DropoutGeneSelection(Preprocess):
             warnings.warn(f"{sum(selected)} genes selected", DropoutWarning)
         return self.filter_columns(data, selected)
 
-    def detection(self, table: np.ndarray) -> Tuple[np.ndarray]:
+    def detection(self, table: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
         mask = table > self.threshold
         if sp.issparse(table):
             zero_rate = 1 - np.squeeze(np.array(mask.mean(axis=0)))

--- a/orangecontrib/single_cell/tests/test_owdropout.py
+++ b/orangecontrib/single_cell/tests/test_owdropout.py
@@ -47,7 +47,7 @@ class TestDropoutGraph(WidgetTest):
 
     def test_on_curve(self):
         self.assertFalse(self.graph._on_curve(1, 0.5))
-        self.graph.set_data(self.results, self.data)
+        self.graph.set_data(self.results, self.data, None)
         self.assertTrue(self.graph._on_curve(1, 0.5))
         self.assertFalse(self.graph._on_curve(1, 1))
 
@@ -59,7 +59,7 @@ class TestDropoutGraph(WidgetTest):
         graph = self.graph
         slot = Mock()
         graph.curve_moved.connect(slot)
-        graph.set_data(self.results, self.data)
+        graph.set_data(self.results, self.data, None)
         graph.is_curve_movable = True
         graph.cursor_event(Mock())
         QTest.mousePress(graph.viewport(), Qt.LeftButton, pos=QPoint(1, 1))

--- a/orangecontrib/single_cell/widgets/owdropout.py
+++ b/orangecontrib/single_cell/widgets/owdropout.py
@@ -117,7 +117,7 @@ class DropoutGraph(pg.PlotWidget):
     def help_event(self, ev):
         if self.__dots is None:
             return False
-        dot = self.__dotAt(self.__dots.mapFromScene(ev.scenePos()))
+        dot = self._dotAt(self.__dots.mapFromScene(ev.scenePos()))
         if dot is not None and dot.data() is not None:
             var, p, n = dot.data()
             q = round(p / n * 100, 1)
@@ -127,7 +127,7 @@ class DropoutGraph(pg.PlotWidget):
         else:
             return False
 
-    def __dotAt(self, pos: QPointF):
+    def _dotAt(self, pos: QPointF):
         pw, ph = self.__dots.pixelWidth(), self.__dots.pixelHeight()
         for s in self.__dots.points():
             sx, sy = s.pos().x(), s.pos().y()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Optimize implementation of #348

##### Description of changes
Due to simplicity the graph was reploted on any parameter change / curve move / input markers change.
Now the graph retains its items, only the curve is moved by re-setting its coordinates.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
