### PR TITLE
ScPreprocess: Add sparse support

### DIFF
--- a/orangecontrib/single_cell/tests/preprocess/test_scpreprocess.py
+++ b/orangecontrib/single_cell/tests/preprocess/test_scpreprocess.py
@@ -5,6 +5,7 @@ import numpy as np
 import numpy.testing as npt
 
 from Orange.data import Table, Domain
+from Orange.widgets.tests.utils import table_dense_sparse
 from orangecontrib.single_cell.preprocess.scpreprocess import (
     LogarithmicScale, Binarize, NormalizeSamples, NormalizeGroups,
     Standardize, SelectMostVariableGenes, DropoutGeneSelection,
@@ -17,15 +18,26 @@ class TestLogarithmicScale(unittest.TestCase):
     def setUpClass(cls):
         cls.table = Table(np.arange(1, 13).reshape((3, 4)))
 
-    def test_default(self):
-        table = LogarithmicScale()(self.table)
-        self.assertIsInstance(table, Table)
-        npt.assert_array_equal(table, np.log2(1 + self.table.X))
-        self.assertNotEqual(table, self.table)
+    @table_dense_sparse
+    def test_default(self, prepare_table):
+        table = prepare_table(self.table)
+        new_table = LogarithmicScale()(table)
+        self.assertIsInstance(new_table, Table)
+        npt.assert_array_equal(new_table, np.log2(1 + self.table.X))
+        self.assertNotEqual(new_table, self.table)
 
-    def test_options(self):
-        table = LogarithmicScale(LogarithmicScale.NaturalLog)(self.table)
-        npt.assert_array_equal(table, np.log(1 + self.table.X))
+    @table_dense_sparse
+    def test_options(self, prepare_table):
+        table = prepare_table(self.table)
+        new_table = LogarithmicScale(LogarithmicScale.NaturalLog)(table)
+        npt.assert_allclose(new_table, np.log(1 + self.table.X))
+
+    @table_dense_sparse
+    def test_preserves_density(self, prepare_table):
+        table = prepare_table(self.table)
+        is_sparse = table.is_sparse()
+        new_table = LogarithmicScale(LogarithmicScale.NaturalLog)(table)
+        self.assertEqual(is_sparse, new_table.is_sparse())
 
 
 class TestBinarize(unittest.TestCase):
@@ -33,37 +45,68 @@ class TestBinarize(unittest.TestCase):
     def setUpClass(cls):
         cls.table = Table(np.arange(12).reshape((3, 4)))
 
-    def test_default(self):
-        table = Binarize()(self.table)
-        self.assertIsInstance(table, Table)
-        self.assertEqual(np.sum(table.X.ravel()[:1]), 0)
-        self.assertEqual(np.sum(table.X.ravel()[1:]), 11)
-        self.assertNotEqual(table, self.table)
+    @table_dense_sparse
+    def test_default(self, prepare_table):
+        table = prepare_table(self.table)
+        new_table = Binarize()(table)
+        self.assertIsInstance(new_table, Table)
+        self.assertEqual(new_table.X[0, 0], 0)
+        self.assertEqual(np.sum(new_table[1]), 4)
+        self.assertNotEqual(new_table, self.table)
 
-    def test_options(self):
-        table = Binarize(Binarize.Greater, 5)(self.table)
-        self.assertEqual(np.sum(table.X.ravel()[:6]), 0)
-        self.assertEqual(np.sum(table.X.ravel()[6:]), 6)
+    @table_dense_sparse
+    def test_options(self, prepare_table):
+        table = prepare_table(self.table)
+        new_table = Binarize(Binarize.Greater, 5)(table)
+        self.assertEqual(np.sum(new_table.X[0]), 0)
+        self.assertEqual(np.sum(new_table.X[1]), 2)
+        self.assertEqual(np.sum(new_table.X[2]), 4)
+
+    @table_dense_sparse
+    def test_preserves_density(self, prepare_table):
+        table = prepare_table(self.table)
+        is_sparse = table.is_sparse()
+        new_table = Binarize(Binarize.Greater, 5)(table)
+        self.assertEqual(is_sparse, new_table.is_sparse())
 
 
 class TestNormalizeSamples(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.table = Table(np.arange(1, 7).reshape((2, 3)).T)
+        cls.table = Table(np.array([
+            [1.5, 8.5, 0],
+            [2, 0, 3],
+            [3, np.nan, 7],
+        ]))
 
-    def test_default(self):
-        table = NormalizeSamples()(self.table)
-        self.assertIsInstance(table, Table)
-        self.assertNotEqual(table, self.table)
-        npt.assert_array_almost_equal(
-            table, [[200000, 800000],
-                    [285714.286, 714285.714],
-                    [333333.333, 666666.667]], decimal=3)
+    @table_dense_sparse
+    def test_default(self, prepare_table):
+        table = prepare_table(self.table)
+        new_table = NormalizeSamples()(table)
+        self.assertIsInstance(new_table, Table)
+        self.assertNotEqual(new_table, self.table)
 
-    def test_options(self):
-        table = NormalizeSamples(NormalizeSamples.Median)(self.table)
+        new_table = new_table.to_dense()
         npt.assert_array_almost_equal(
-            table, [[1.4, 5.6], [2, 5], [2.333, 4.667]], decimal=3)
+            new_table, [[150000, 850000, 0],
+                        [400000, 0, 600000],
+                        [300000, np.nan, 700000]])
+
+    @table_dense_sparse
+    def test_options(self, prepare_table):
+        table = prepare_table(self.table)
+        new_table = NormalizeSamples(NormalizeSamples.Median)(table)
+        npt.assert_array_almost_equal(
+            new_table,
+            [[1.5, 8.5, 0], [4, 0, 6], [3, np.nan, 7]],
+        )
+
+    @table_dense_sparse
+    def test_preserves_density(self, prepare_table):
+        table = prepare_table(self.table)
+        is_sparse = table.is_sparse()
+        new_table = NormalizeSamples(NormalizeSamples.Median)(table)
+        self.assertEqual(is_sparse, new_table.is_sparse())
 
 
 class TestNormalizeGroups(unittest.TestCase):
@@ -74,18 +117,32 @@ class TestNormalizeGroups(unittest.TestCase):
                         metas=table.domain.attributes[-1:])
         cls.table = table.transform(domain)
 
-    def test_default(self):
-        table = NormalizeGroups(-1)(self.table)
-        self.assertIsInstance(table, Table)
-        self.assertNotEqual(table, self.table)
-        npt.assert_array_almost_equal(
-            table.X, [[83333.333, 333333.333],
-                      [166666.667, 416666.667],
-                      [333333.333, 666666.667]], decimal=3)
+    @table_dense_sparse
+    def test_default(self, prepare_table):
+        table = prepare_table(self.table)
+        new_table = NormalizeGroups(-1)(table)
+        self.assertIsInstance(new_table, Table)
+        self.assertNotEqual(new_table, self.table)
 
-    def test_options(self):
-        table = NormalizeGroups(-1, NormalizeGroups.Median)(self.table)
-        npt.assert_array_equal(table.X, [[0.5, 2], [1, 2.5], [2, 4]])
+        new_table = new_table.to_dense()
+        npt.assert_array_almost_equal(
+            new_table.X, [[83333.333, 333333.333],
+                          [166666.667, 416666.667],
+                          [333333.333, 666666.667]], decimal=3)
+
+    @table_dense_sparse
+    def test_options(self, prepare_table):
+        table = prepare_table(self.table)
+        new_table = NormalizeGroups(-1, NormalizeGroups.Median)(table)
+        new_table = new_table.to_dense()
+        npt.assert_array_equal(new_table.X, [[0.5, 2], [1, 2.5], [2, 4]])
+
+    @table_dense_sparse
+    def test_preserves_density(self, prepare_table):
+        table = prepare_table(self.table)
+        is_sparse = table.is_sparse()
+        new_table = NormalizeGroups(-1, NormalizeGroups.Median)(table)
+        self.assertEqual(is_sparse, new_table.is_sparse())
 
 
 class TestStandardize(unittest.TestCase):
@@ -110,61 +167,115 @@ class TestSelectMostVariableGenes(unittest.TestCase):
     def setUpClass(cls):
         path = os.path.join(os.path.dirname(__file__), '..', "data")
         data = Table(os.path.join(path, 'dermatology.tab'))
-        cls.data = data.transform(Domain(data.domain.attributes[:-1],
-                                         data.domain.class_vars))
-        cls.variance = np.nanvar(cls.data.X, axis=0)
-        cls.mean = np.nanmean(cls.data.X, axis=0)
+        cls.table = data.transform(Domain(data.domain.attributes[:-1],
+                                          data.domain.class_vars))
+        cls.variance = np.nanvar(cls.table.X, axis=0)
+        cls.mean = np.nanmean(cls.table.X, axis=0)
 
-    def test_default(self):
+    @table_dense_sparse
+    def test_default(self, prepare_table):
         table = Table(np.arange(12).reshape((3, 4)).T ** (1 / 2))
+        table = prepare_table(table)
         pp_table = SelectMostVariableGenes(n_genes=2, n_groups=2)(table)
         self.assertIsInstance(pp_table, Table)
         self.assertNotEqual(pp_table, table)
         npt.assert_array_equal(pp_table, table[:, :2])
 
-    def test_options_dispersion(self):
-        attrs, cls = self.data.domain.attributes, self.data.domain.class_vars
+    @table_dense_sparse
+    def test_options_dispersion(self, prepare_table):
+        attrs, cls = self.table.domain.attributes, self.table.domain.class_vars
         inds = sorted(np.argsort(self.variance / self.mean))
-        data = self.data.transform(Domain(tuple(np.array(attrs)[inds]), cls))
-        npt.assert_array_equal(
-            SelectMostVariableGenes(method=SelectMostVariableGenes.Dispersion,
-                                    n_groups=None)(self.data), data)
+        data = self.table.transform(Domain(tuple(np.array(attrs)[inds]), cls))
 
-    def test_options_variance(self):
-        attrs, cls = self.data.domain.attributes, self.data.domain.class_vars
+        table = prepare_table(data)
+        filtered_data = SelectMostVariableGenes(
+            method=SelectMostVariableGenes.Dispersion, n_groups=None
+        )(table)
+        npt.assert_array_equal(filtered_data, data)
+
+    @table_dense_sparse
+    def test_options_variance(self, prepare_table):
+        attrs, cls = self.table.domain.attributes, self.table.domain.class_vars
         inds = sorted(np.argsort(self.variance))
-        data = self.data.transform(Domain(tuple(np.array(attrs)[inds]), cls))
-        npt.assert_array_equal(
-            SelectMostVariableGenes(method=SelectMostVariableGenes.Variance,
-                                    n_groups=None)(self.data), data)
+        table = self.table.transform(Domain(tuple(np.array(attrs)[inds]), cls))
+        table = prepare_table(table)
 
-    def test_options_mean(self):
-        attrs, cls = self.data.domain.attributes, self.data.domain.class_vars
+        filtered_table = SelectMostVariableGenes(
+            method=SelectMostVariableGenes.Dispersion, n_groups=None
+        )(table)
+
+        npt.assert_array_equal(filtered_table, table)
+
+    @table_dense_sparse
+    def test_options_mean(self, prepare_table):
+        attrs, cls = self.table.domain.attributes, self.table.domain.class_vars
         inds = sorted(np.argsort(self.mean))
-        data = self.data.transform(Domain(tuple(np.array(attrs)[inds]), cls))
-        npt.assert_array_equal(
-            SelectMostVariableGenes(method=SelectMostVariableGenes.Mean,
-                                    n_groups=None)(self.data), data)
+        table = self.table.transform(Domain(tuple(np.array(attrs)[inds]), cls))
+        table = prepare_table(table)
+
+        filtered_table = SelectMostVariableGenes(
+            method=SelectMostVariableGenes.Dispersion, n_groups=None
+        )(table)
+
+        npt.assert_array_equal(filtered_table, table)
+
+    @table_dense_sparse
+    def test_preserves_density(self, prepare_table):
+        table = prepare_table(self.table)
+        is_sparse = table.is_sparse()
+        filtered_table = SelectMostVariableGenes(
+            method=SelectMostVariableGenes.Dispersion, n_groups=None
+        )(table)
+        self.assertEqual(is_sparse, filtered_table.is_sparse())
 
 
 class TestDropoutGeneSelection(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         path = os.path.join(os.path.dirname(__file__), '..', "data")
-        cls.data = Table(os.path.join(path, 'dermatology.tab'))
+        cls.table = Table(os.path.join(path, 'dermatology.tab'))
 
-    def test_default(self):
+    @table_dense_sparse
+    def test_default(self, prepare_table):
         n_genes = 2
-        table = DropoutGeneSelection(n_genes)(self.data)
-        self.assertIsInstance(table, Table)
-        self.assertEqual(len(table.domain.attributes), n_genes)
+        table = prepare_table(self.table)
+        filtered_table = DropoutGeneSelection(n_genes)(table)
+        self.assertIsInstance(filtered_table, Table)
+        self.assertEqual(len(filtered_table.domain.attributes), n_genes)
 
-    def test_warning(self):
+    @table_dense_sparse
+    def test_detection(self, prepare_table):
+        table = prepare_table(self.table)
+        preprocessor = DropoutGeneSelection(n_genes=2)
+        zero_rate, mean_expr = preprocessor.detection(table.X)
+        self.assertEqual(len(zero_rate), len(table.domain.attributes))
+        self.assertEqual(len(mean_expr), len(table.domain.attributes))
+        npt.assert_allclose(
+            zero_rate[:5],
+            np.array([0.01092896, 0.02185792, 0.16120219, 0.32240437, 0.61202186]),
+            atol=1e-7,
+        )
+        npt.assert_allclose(
+            mean_expr[:5],
+            np.array([0.9879741, 0.77491075, 0.78471751, 0.88894012, 0.58119243]),
+            atol=1e-7,
+        )
+
+    @table_dense_sparse
+    def test_warning(self, prepare_table):
         n_genes = 30
+        table = prepare_table(self.table)
         with warnings.catch_warnings(record=True) as w:
-            table = DropoutGeneSelection(n_genes)(self.data)
-        self.assertIsInstance(table, Table)
-        self.assertNotEqual(len(table.domain.attributes), n_genes)
+            filtered_table = DropoutGeneSelection(n_genes)(table)
+        self.assertIsInstance(filtered_table, Table)
+        self.assertNotEqual(len(filtered_table.domain.attributes), n_genes)
         dropout_warnings = [warning for warning in w if
                             issubclass(warning.category, DropoutWarning)]
         self.assertEqual(len(dropout_warnings), 1)
+
+    @table_dense_sparse
+    def test_preserves_density(self, prepare_table):
+        table = prepare_table(self.table)
+        is_sparse = table.is_sparse()
+        filtered_table = DropoutGeneSelection(3)(table)
+        self.assertEqual(is_sparse, filtered_table.is_sparse())


### PR DESCRIPTION
##### Issue
[`single_cell.preprocess.scpreprocess`](https://github.com/biolab/orange3-single-cell/blob/master/orangecontrib/single_cell/preprocess/scpreprocess.py) does not support sparse data.

##### Description of changes
Add sparse support to preprocessors. Does not include [`single_cell.preprocess.scpreprocess.Standardize`](https://github.com/biolab/orange3-single-cell/blob/master/orangecontrib/single_cell/preprocess/scpreprocess.py#L107-L118), as some thought will have to be put into how to handle this elegantly.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
