### PR TITLE
Several fixes

### DIFF
--- a/orangecontrib/single_cell/tests/test_owdatasets.py
+++ b/orangecontrib/single_cell/tests/test_owdatasets.py
@@ -1,16 +1,24 @@
 import unittest
 from unittest.mock import patch
 
+import pkg_resources
+from packaging import version
+
 from orangecontrib.single_cell.widgets.owscdatasets import OWscDataSets
 from Orange.widgets.tests.base import WidgetTest
 
 
 class TestOWscDataSets(WidgetTest):
-
     def test_widget_setup(self):
-        with patch.object(OWscDataSets, "list_remote", staticmethod(lambda: [])):
-            self.widget = self.create_widget(OWscDataSets)
-            self.wait_until_finished(self.widget)
+        orange_version = pkg_resources.get_distribution("orange3").version
+        if version.parse(orange_version) > version.parse("3.27.0"):
+            with patch("Orange.widgets.data.owdatasets.list_remote", lambda _: {}):
+                self.widget = self.create_widget(OWscDataSets)
+                self.wait_until_finished(self.widget)
+        else:
+            with patch.object(OWscDataSets, "list_remote", staticmethod(lambda: [])):
+                self.widget = self.create_widget(OWscDataSets)
+                self.wait_until_finished(self.widget)
 
 
 if __name__ == '__main__':

--- a/orangecontrib/single_cell/tests/test_owfilter.py
+++ b/orangecontrib/single_cell/tests/test_owfilter.py
@@ -1,5 +1,6 @@
+import unittest
+
 import numpy as np
-import numpy.testing
 
 import Orange.data
 from Orange.widgets.tests.base import WidgetTest
@@ -117,3 +118,6 @@ class TestOWFilterCells(WidgetTest):
         np.testing.assert_allclose(log1p(x), np.log10(1 + x))
         np.testing.assert_allclose(expm1(log1p(x)), x)
 
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orangecontrib/single_cell/tests/test_owloaddata.py
+++ b/orangecontrib/single_cell/tests/test_owloaddata.py
@@ -1,4 +1,5 @@
 import os
+import unittest
 
 import numpy as np
 import numpy.testing as npt
@@ -332,7 +333,7 @@ class TestOWLoadData(WidgetTest):
             self.assertDictEqual(attribute.attributes, {})
 
     def _test_load_data_x(self, x, df):
-        npt.assert_array_equal(x, df.values.T)
+        npt.assert_array_almost_equal(x, df.values.T)
 
     def _test_load_data_metas(self, metas, df):
         npt.assert_array_equal(metas, df.values)
@@ -369,3 +370,7 @@ class TestOWLoadData(WidgetTest):
     #     self.assertIsNotNone(data)
     #     self.assertEqual(data.X.shape, (3, 7))
     #     widget.set_dataset(data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orangecontrib/single_cell/widgets/load_data.py
+++ b/orangecontrib/single_cell/widgets/load_data.py
@@ -625,6 +625,7 @@ class ExcelLoader(Loader):
 
     @staticmethod
     def df_read_func(*args, **kwargs):
+        kwargs.pop("sep")
         return pd.read_excel(*args, **kwargs)
 
 

--- a/orangecontrib/single_cell/widgets/owfilter.py
+++ b/orangecontrib/single_cell/widgets/owfilter.py
@@ -742,8 +742,10 @@ class OWFilter(widget.OWWidget):
                         ),
                         data
                     )
-                if len(data) == 0 or \
-                        len(data.domain) + len(data.domain.metas) == 0:
+                if (
+                    len(data) == 0
+                    or len(data.domain.variables) + len(data.domain.metas) == 0
+                ):
                     data = None
             elif self.filter_type() == Data:
                 dmin, dmax = self.limit_lower, self.limit_upper

--- a/orangecontrib/single_cell/widgets/owloaddata.py
+++ b/orangecontrib/single_cell/widgets/owloaddata.py
@@ -339,7 +339,7 @@ class OWLoadData(widget.OWWidget):
             self.col_annotations_combo.model(),
             [self.resolve_path(p) for p in self._recent_col_annotations]
         )
-        self._update_summary()
+        self.__update_summary()
         self._update_warning()
 
         if self._last_path != "" and os.path.exists(self._last_path):
@@ -481,7 +481,7 @@ class OWLoadData(widget.OWWidget):
         self.recent_combo.setCurrentIndex(0)
 
         self._data_loader = get_data_loader(path)
-        self._update_summary()
+        self.__update_summary()
         self.setup_gui()
         self._invalidate()
 
@@ -556,7 +556,7 @@ class OWLoadData(widget.OWWidget):
 
         self.annotation_files_box.setEnabled(loader.ENABLE_ANNOTATIONS)
 
-    def _update_summary(self):
+    def __update_summary(self):
         size = self._data_loader.file_size
         ncols = self._data_loader.n_cols
         nrows = self._data_loader.n_rows

--- a/orangecontrib/single_cell/widgets/owscdatasets.py
+++ b/orangecontrib/single_cell/widgets/owscdatasets.py
@@ -27,7 +27,7 @@ class OWscDataSets(Orange.widgets.data.owdatasets.OWDataSets):
         ['title',        {'label': 'Title'}],
         ['size',         {'label': 'Size'}],
         ['instances',    {'label': 'Cells'}],
-        ['num_of_genes', {'label': 'Genes'}],
+        ['variables',    {'label': 'Genes'}],
         ['taxid',        {'label': 'Organism'}],
         ['target',       {'label': 'Target'}],
         ['tags',         {'label': 'Tags'}]
@@ -54,7 +54,7 @@ class OWscDataSets(Orange.widgets.data.owdatasets.OWDataSets):
             Orange.widgets.data.owdatasets.NumericalDelegate(self)
         )
         self.view.setItemDelegateForColumn(
-            self.Header.num_of_genes,
+            self.Header.variables,
             Orange.widgets.data.owdatasets.NumericalDelegate(self)
         )
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if __name__ == '__main__':
             'Orange3>=3.23.0',
             'orange3-bioinformatics>=4.0.0',
             'fastdtw==0.3.2',
-            'pandas>=0.23,<1.1',
+            'pandas>=0.23',
             'loompy>=2.0.10',
             'xlrd~=1.2.0',
             'anndata>=0.6.21',


### PR DESCRIPTION
This PR solves several issues in the addon:
- Addon now support Pandas version >=1.1
- SC Datasets is updated to a newer version of the Orange Dataset widget
- Updated deprecated `len(domain)` in filter
- `_upate_summary` function is now function in the `orangewidget.sinals` which interfered with `_upate_summary`  in Filter widget. Function in Filter widget is temporarily renamed. This functionality could be later changed or removed when default summaries will be available by Orange.
- 