### PR TITLE
Keep docutils <0.16 for documentation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,9 @@ if __name__ == '__main__':
             'scikit-learn',
         ],
         extras_require={
-            'doc': ['sphinx', 'recommonmark', 'sphinx_rtd_theme'],
+            # docutils changed html in 0.17; fixing to 0.16 until parser fixed
+            # todo: remove docutils when parser fixed in widget-base and released
+            'doc': ['sphinx', 'recommonmark', 'sphinx_rtd_theme', 'docutils<0.17'],
             'package': ['twine', 'wheel'],
             'test': [
                 'coverage',


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Docutils 0.17 causes different html structure which is not correctly handled with documentation handler in widget-base.

##### Description of changes
Keep it below 0.17 until the documentation handler is fixed.




##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
