### PR TITLE
Add counts per 10k as a normalization option

### DIFF
--- a/orangecontrib/single_cell/preprocess/scpreprocess.py
+++ b/orangecontrib/single_cell/preprocess/scpreprocess.py
@@ -63,8 +63,8 @@ class Binarize(Preprocess):
 
 
 class Normalize(Preprocess):
-    Method = Enum("Normalize", ("CPM", "Median"), qualname="Normalize.Method")
-    CPM, Median = Method
+    Method = Enum("Normalize", ("CPM", "Median", "CP10K"), qualname="Normalize.Method")
+    CPM, Median, CP10K = Method
 
     def __init__(self, method=CPM):
         self.method = method
@@ -89,6 +89,9 @@ class NormalizeSamples(Normalize):
 
         if self.method == NormalizeSamples.Median:
             factor = np.nanmedian(row_sums)
+        
+        elif self.method == NormalizeSamples.CP10K:
+            factor = 1e4
         else:
             factor = 1e6
 

--- a/orangecontrib/single_cell/widgets/owscpreprocess.py
+++ b/orangecontrib/single_cell/widgets/owscpreprocess.py
@@ -145,9 +145,10 @@ class NormalizeEditor(ScBaseEditor):
         form = QFormLayout()
         cpm_b = QRadioButton("Counts per million", checked=True)
         med_b = QRadioButton("Median")
+        cp10k_b = QRadioButton("Counts per 10k")
         self.group = QButtonGroup()
         self.group.buttonClicked.connect(self._on_button_clicked)
-        for i, button in enumerate([cpm_b, med_b]):
+        for i, button in enumerate([cpm_b, med_b, cp10k_b]):
             index = index_to_enum(Normalize.Method, i).value
             self.group.addButton(button, index - 1)
             form.addRow(button)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Besides CPM or counts per million, the single-cell literature also mentions CP10K or counts per 10000 as a normalization method. The difference in the method is noticeable after logarithmizing the data and in later downstream analysis.

##### Description of changes
Added a few lines of code to NormalizeSamples in scpreprocess.py and NormalizeEditor in owspreprocess.py.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
