### PR TITLE
[CI] Workflow for automated release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,12 @@
+name: Release
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: biolab/orange-ci-cd/.github/workflows/release.yml@master
+    with:
+      pure-python: true
+    secrets: inherit


### PR DESCRIPTION
This PR introduces a reusable workflow that allows release automatically. It is reusable -- we do not need to update every repository separately. Instruction on how to use it is in [Orange wiki in Automated release section](https://github.com/biolab/orange3/wiki/Preparing-an-Add-on-release#automated-release).

