### PR TITLE
[FIX] LoadData - Manually add gene and cell annotations, correct Source name

### DIFF
--- a/orangecontrib/single_cell/widgets/load_data.py
+++ b/orangecontrib/single_cell/widgets/load_data.py
@@ -488,10 +488,18 @@ class MtxLoader(Loader):
 
     def _set_annotation_files(self):
         dir_name, _ = os.path.split(self._file_name)
-        genes_path = os.path.join(dir_name, "genes.tsv")
-        if os.path.isfile(genes_path):
-            self.col_annotation_file = RecentPath.create(genes_path, [])
-        barcodes_path = os.path.join(dir_name, "barcodes.tsv")
+        genes_paths = ['genes.tsv', 'features.tsv', 'genes.tsv.gz', 'features.tsv.gz']
+        for genes_path in genes_paths:
+            genes_path = os.path.join(dir_name, genes_path)
+            if os.path.isfile(genes_path):
+                self.col_annotation_file = RecentPath.create(genes_path, [])
+                break
+        barcodes_paths = ['barcodes.tsv', 'barcodes.tsv.gz']
+        for barcodes_path in barcodes_paths:
+            barcodes_path = os.path.join(dir_name, barcodes_path)
+            if os.path.isfile(barcodes_path):
+                self.row_annotation_file = RecentPath.create(barcodes_path, [])
+                break
         if os.path.isfile(barcodes_path):
             self.row_annotation_file = RecentPath.create(barcodes_path, [])
 

--- a/orangecontrib/single_cell/widgets/owloaddata.py
+++ b/orangecontrib/single_cell/widgets/owloaddata.py
@@ -613,6 +613,7 @@ class OWLoadData(widget.OWWidget):
             pathitem = RecentPath.create(filename, [])
             index = insert_recent_path(m, pathitem)
             self.row_annotations_combo.setCurrentIndex(index)
+            self._row_annotations_combo_changed()
             self._invalidate()
 
     @Slot()
@@ -632,6 +633,7 @@ class OWLoadData(widget.OWWidget):
             pathitem = RecentPath.create(filename, [])
             index = insert_recent_path(m, pathitem)
             self.col_annotations_combo.setCurrentIndex(index)
+            self._col_annotations_combo_changed()
             self._invalidate()
 
     def _invalidate(self):


### PR DESCRIPTION
##### Issue
Fixes #389.
<!-- Or a short description, if the issue does not exist. -->


##### Description of changes
This pull request resolves several issues. First, it fixes a bug that prevented manual addition of cell and gene annotations. Additionally, files named 'genes.tsv', 'features.tsv', 'genes.tsv.gz', and 'features.tsv.gz' for genes, as well as 'barcodes.tsv' and 'barcodes.tsv.gz' for barcodes, are now automatically recognized and added.

Furthermore, it addresses a bug where source names were not correctly assigned. Previously, when loading two scRNA matrices with different source names, both sources would incorrectly inherit the source name of the first one. This issue has now been fixed.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
