### PR TITLE
[FIX] LoadData - Bugs with gene and cell annotations

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,3 +16,4 @@ Widgets
    widgets/score_genes
    widgets/score_cells
    widgets/dot_matrix
+   widgets/spatial_autocorrelation

--- a/doc/widgets.json
+++ b/doc/widgets.json
@@ -75,6 +75,13 @@
     "icon": "../orangecontrib/single_cell/widgets/icons/DotMatrix.svg",
     "background": "light-blue",
     "keywords": []
+   },
+   {
+    "text": "Spatial Autocorrelation Scorer",
+    "doc": "widgets/spatial_autocorrelation.md",
+    "icon": "../orangecontrib/single_cell/widgets/icons/SpatialAutocorrelation.svg",
+    "background": "light-blue",
+    "keywords": []
    }
   ]
  ]

--- a/orangecontrib/single_cell/widgets/load_data.py
+++ b/orangecontrib/single_cell/widgets/load_data.py
@@ -488,12 +488,18 @@ class MtxLoader(Loader):
 
     def _set_annotation_files(self):
         dir_name, _ = os.path.split(self._file_name)
-        genes_path = os.path.join(dir_name, "genes.tsv")
-        if os.path.isfile(genes_path):
-            self.col_annotation_file = RecentPath.create(genes_path, [])
-        barcodes_path = os.path.join(dir_name, "barcodes.tsv")
-        if os.path.isfile(barcodes_path):
-            self.row_annotation_file = RecentPath.create(barcodes_path, [])
+        genes_paths = ['genes.tsv', 'features.tsv', 'genes.tsv.gz', 'features.tsv.gz']
+        for genes_path in genes_paths:
+            genes_path = os.path.join(dir_name, genes_path)
+            if os.path.isfile(genes_path):
+                self.col_annotation_file = RecentPath.create(genes_path, [])
+                break
+        barcodes_paths = ['barcodes.tsv', 'barcodes.tsv.gz']
+        for barcodes_path in barcodes_paths:
+            barcodes_path = os.path.join(dir_name, barcodes_path)
+            if os.path.isfile(barcodes_path):
+                self.row_annotation_file = RecentPath.create(barcodes_path, [])
+                break
 
     def _set_enable_annotations(self):
         # 10x gene-barcode matrix
@@ -756,13 +762,21 @@ class Concatenate:
                             metas=sorted(metas, key=key))
             concat_data_t = concat_data.transform(domain)
             data_t = data.transform(domain)
-            source_var.values + (source_name, )
+
+            new_values = source_var.values + (source_name,)
+            new_source_var = DiscreteVariable(source_var.name, values=new_values)
+            new_metas = tuple(var if var.name != source_var.name else new_source_var for var in domain.metas)
+            new_domain = Domain(domain.attributes, metas=new_metas)
+            concat_data_t = concat_data_t.transform(new_domain)
+            data_t = data_t.transform(new_domain)
+            source_var_index = new_source_var.values.index(source_name)
             # metas can be unlocked, source_var added to metas by append_source_name
             with data_t.unlocked(data_t.metas):
-                data_t[:, source_var] = np.full(
-                    (len(data), 1), len(source_var.values) - 1, dtype=object
+                data_t[:, new_source_var] = np.full(
+                    (len(data_t), 1), source_var_index, dtype=object
                 )
             concat_data = Table.concatenate((concat_data_t, data_t), axis=0)
+            source_var = new_source_var # Update source_var for the next iteration
         return concat_data
 
     @staticmethod

--- a/orangecontrib/single_cell/widgets/owloaddata.py
+++ b/orangecontrib/single_cell/widgets/owloaddata.py
@@ -613,6 +613,7 @@ class OWLoadData(widget.OWWidget):
             pathitem = RecentPath.create(filename, [])
             index = insert_recent_path(m, pathitem)
             self.row_annotations_combo.setCurrentIndex(index)
+            self._row_annotations_combo_changed()
             self._invalidate()
 
     @Slot()
@@ -632,6 +633,7 @@ class OWLoadData(widget.OWWidget):
             pathitem = RecentPath.create(filename, [])
             index = insert_recent_path(m, pathitem)
             self.col_annotations_combo.setCurrentIndex(index)
+            self._col_annotations_combo_changed()
             self._invalidate()
 
     def _invalidate(self):


### PR DESCRIPTION
##### Issue


##### Description of changes

This pull request resolves several issues. First, it fixes a bug that prevented manual addition of cell and gene annotations. Additionally, files named 'genes.tsv', 'features.tsv', 'genes.tsv.gz', and 'features.tsv.gz' for genes, as well as 'barcodes.tsv' and 'barcodes.tsv.gz' for barcodes, are now automatically recognized and added.

Furthermore, it addresses a bug where source names were not correctly assigned. Previously, when loading two scRNA matrices with different source names, both sources would incorrectly inherit the source name of the first one. This issue has now been fixed.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
