### PR TITLE
[FIX] Multi Sample: Add postfix to non-unique names

### DIFF
--- a/orangecontrib/single_cell/widgets/load_data.py
+++ b/orangecontrib/single_cell/widgets/load_data.py
@@ -17,6 +17,7 @@ from Orange.data.io import (
     Compression, open_compressed, PickleReader,
     guess_data_type, sanitize_variable
 )
+from Orange.data.util import get_unique_names
 from Orange.widgets.utils.filedialogs import RecentPath
 from openpyxl.reader.excel import load_workbook
 
@@ -763,6 +764,7 @@ class Concatenate:
             concat_data_t = concat_data.transform(domain)
             data_t = data.transform(domain)
 
+            source_name = get_unique_names(source_var.values, source_name)
             new_values = source_var.values + (source_name,)
             new_source_var = DiscreteVariable(source_var.name, values=new_values)
             new_metas = tuple(var if var.name != source_var.name else new_source_var for var in domain.metas)

--- a/orangecontrib/single_cell/widgets/owmultisample.py
+++ b/orangecontrib/single_cell/widgets/owmultisample.py
@@ -412,7 +412,7 @@ class OWMultiSample(owloaddata.OWLoadData):
         dlg.setNameFilters(filters)
         if filters:
             dlg.selectNameFilter(filters[-1])
-        if dlg.exec_() == QFileDialog.Accepted:
+        if dlg.exec() == QFileDialog.Accepted:
             for filename in dlg.selectedFiles():
                 self.set_current_path(filename)
                 self.select_last_item()
@@ -505,12 +505,6 @@ class OWMultiSample(owloaddata.OWLoadData):
 
 
 if __name__ == "__main__":
-    from AnyQt.QtWidgets import QApplication
+    from orangewidget.utils.widgetpreview import WidgetPreview
 
-    app = QApplication([])
-    w = OWMultiSample()
-    w.show()
-    w.raise_()
-    app.exec_()
-    w.saveSettings()
-    w.onDeleteWidget()
+    WidgetPreview(OWMultiSample).run()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The widget crashes with `ValueError: Duplicate values in DiscreteVariable` when opening multiple files with the same name.
![image](https://github.com/user-attachments/assets/9b2a1315-68b8-44cd-b395-9ae5c962e45d)

##### Description of changes
Make source names unique before creating the output table.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
