### PR TITLE
[FIX] contingency_table: Fix type error due to implicit float/int conversion

### DIFF
--- a/orangecontrib/single_cell/tests/test_owdotmatrix.py
+++ b/orangecontrib/single_cell/tests/test_owdotmatrix.py
@@ -214,6 +214,13 @@ class TestOWDotMatrix(WidgetTest):
         self.assertEqual(1, len(cont_data.domain.metas))
         self.assertEqual("Gene", str(cont_data.domain.metas[0]))
 
+    def test_paint(self):
+        w = self.widget
+        w.grab()
+        self.send_signal(w.Inputs.data, self.iris)
+        w.grab()
+        self.send_signal(w.Inputs.data, self.iris)
+        w.grab()
 
 if __name__ == "__main__":
     unittest.main()

--- a/orangecontrib/single_cell/widgets/contingency_table.py
+++ b/orangecontrib/single_cell/widgets/contingency_table.py
@@ -84,7 +84,7 @@ class CircleItemDelegate(BorderedItemDelegate, gui.VerticalItemDelegate):
             QStyledItemDelegate.paint(self, painter, option, index)
             area = index.data(CircleAreaRole)
             rect = option.rect
-            radius = max(1, self.max_diameter/2*sqrt(area))
+            radius = max(1, int(self.max_diameter/2*sqrt(area)))
             painter.setPen(Qt.transparent)
             painter.setBrush(Qt.blue)
             painter.setRenderHint(QPainter.Antialiasing)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fix type error due to implicit float/int conversion
```
----------------------------- TypeError Exception -----------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/devel/orange3-single-cell/orangecontrib/single_cell/widgets/contingency_table.py", line 91, in paint
    painter.drawEllipse(rect.center(), radius, radius)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: arguments did not match any overloaded call:
  drawEllipse(self, r: QRectF): argument 1 has unexpected type 'QPoint'
  drawEllipse(self, r: QRect): argument 1 has unexpected type 'QPoint'
  drawEllipse(self, x: int, y: int, w: int, h: int): argument 1 has unexpected type 'QPoint'
  drawEllipse(self, center: QPointF, rx: float, ry: float): argument 1 has unexpected type 'QPoint'
  drawEllipse(self, center: QPoint, rx: int, ry: int): argument 2 has unexpected type 'float'
-------------------------------------------------------------------------------
```

##### Description of changes


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
