### PR TITLE
[FIX] owaligndatasets: Fix index error when nvalues > 9

### DIFF
--- a/orangecontrib/single_cell/widgets/owaligndatasets.py
+++ b/orangecontrib/single_cell/widgets/owaligndatasets.py
@@ -355,9 +355,7 @@ class OWAlignDatasets(widget.OWWidget):
         shared_correlations = self._shared_correlations
         p = MAX_COMPONENTS
 
-        # Colors chosen based on: http://colorbrewer2.org/?type=qualitative&scheme=Set1&n=9
-        colors = ['#e41a1c', '#377eb8', '#4daf4a', '#984ea3', '#ff7f00', '#ffff33', '#a65628',
-                  '#f781bf', '#999999']
+        colors = self.source_id.palette
 
         self.clear_legend()
         self._legend = self.plot.addLegend(offset=(-1, 1))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

When source indicator variable has more then 9 values widget crashes with 
```
Traceback (most recent call last):
  File "/Applications/Orange.app/Contents/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/orangecanvas/scheme/signalmanager.py", line 1180, in __process_next
    if self.__process_next_helper(use_max_active=True):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Applications/Orange.app/Contents/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/orangecanvas/scheme/signalmanager.py", line 1218, in __process_next_helper
    self.process_node(selected_node)
  File "/Applications/Orange.app/Contents/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/orangecanvas/scheme/signalmanager.py", line 846, in process_node
    self.send_to_node(node, signals_in)
  File "/Applications/Orange.app/Contents/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/orangewidget/workflow/widgetsscheme.py", line 817, in send_to_node
    self.process_signals_for_widget(node, widget, signals)
  File "/Applications/Orange.app/Contents/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/orangewidget/workflow/widgetsscheme.py", line 831, in process_signals_for_widget
    process_signals_for_widget(widget, signals, workflow)
  File "/Applications/Orange.app/Contents/Frameworks/Python.framework/Versions/3.12/lib/python3.12/functools.py", line 912, in wrapper
    return dispatch(args[0].__class__)(*args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Applications/Orange.app/Contents/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/orangewidget/workflow/widgetsscheme.py", line 934, in process_signals_for_widget
    process_signal_input(input_meta, widget, signal, workflow)
  File "/Applications/Orange.app/Contents/Frameworks/Python.framework/Versions/3.12/lib/python3.12/functools.py", line 912, in wrapper
    return dispatch(args[0].__class__)(*args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Applications/Orange.app/Contents/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/orangewidget/workflow/widgetsscheme.py", line 897, in process_signal_input_default
    notify_input_helper(
  File "/Applications/Orange.app/Contents/Frameworks/Python.framework/Versions/3.12/lib/python3.12/functools.py", line 912, in wrapper
    return dispatch(args[0].__class__)(*args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Applications/Orange.app/Contents/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/orangewidget/utils/signals.py", line 735, in set_input_helper
    handler(*args)
  File "/Applications/Orange.app/Contents/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/orangewidget/utils/signals.py", line 208, in summarize_wrapper
    method(widget, value)
  File "/Applications/Orange.app/Contents/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/Orange/widgets/utils/sql.py", line 31, in new_f
    return f(widget, data, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Applications/Orange.app/Contents/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/orangecontrib/single_cell/widgets/owaligndatasets.py", line 253, in set_data
    self.fit()
  File "/Applications/Orange.app/Contents/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/orangecontrib/single_cell/widgets/owaligndatasets.py", line 281, in fit
    self._setup_plot()
  File "/Applications/Orange.app/Contents/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/orangecontrib/single_cell/widgets/owaligndatasets.py", line 373, in _setup_plot
    pen=pg.mkPen(QColor(colors[i]), width=2),
                        ~~~~~~^^^
IndexError: list index out of range
```

##### Description of changes

Replace hardcoded colors with variable's palette.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
