### PR TITLE
[FIX] Fix wrong condition for `checkState()`

### DIFF
--- a/orangecontrib/single_cell/tests/test_owbatchnorm.py
+++ b/orangecontrib/single_cell/tests/test_owbatchnorm.py
@@ -86,6 +86,21 @@ class TestOWBatchNorm(WidgetTest):
         output = self.get_output(self.widget.Outputs.data)
         self.assertFalse((output.X == data.X).any())
 
+    def test_batch_var_change(self):
+        data = Table("iris")
+        w = self.widget
+        self.send_signal(w.Inputs.data, data)
+
+        self.widget.model.item(0).setCheckState(Qt.CheckState.Checked)
+        self.assertEqual(w.batch_vars, [data.domain["iris"]])
+        output = self.get_output(w.Outputs.data)
+        self.assertNotEqual(output.X[0, 0], data.X[0, 0])
+
+        self.widget.model.item(0).setCheckState(Qt.CheckState.Unchecked)
+        self.assertEqual(w.batch_vars, [])
+        output = self.get_output(w.Outputs.data)
+        self.assertEqual(output.X[0, 0], data.X[0, 0])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/orangecontrib/single_cell/tests/test_owharmony.py
+++ b/orangecontrib/single_cell/tests/test_owharmony.py
@@ -1,0 +1,24 @@
+from AnyQt.QtCore import Qt
+from Orange.data import Table
+from Orange.widgets.tests.base import WidgetTest
+from orangecontrib.single_cell.widgets.owharmony import OWHarmony
+
+
+class TestOWBatchNorm(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWHarmony)
+
+    def test_batch_var_change(self):
+        data = Table("iris")
+        w = self.widget
+        self.send_signal(w.Inputs.data, data)
+
+        self.widget.model.item(0).setCheckState(Qt.CheckState.Checked)
+        self.assertEqual(w.batch_vars, [data.domain["iris"]])
+        output = self.get_output(w.Outputs.data)
+        self.assertNotEqual(output.X[0, 0], data.X[0, 0])
+
+        self.widget.model.item(0).setCheckState(Qt.CheckState.Unchecked)
+        self.assertEqual(w.batch_vars, [])
+        output = self.get_output(w.Outputs.data)
+        self.assertEqual(output.X[0, 0], data.X[0, 0])

--- a/orangecontrib/single_cell/widgets/owbatchnorm.py
+++ b/orangecontrib/single_cell/widgets/owbatchnorm.py
@@ -131,7 +131,7 @@ class OWBatchNorm(OWWidget):
         self.commit.deferred()
 
     def __selected_batch_vars_changed(self, item):
-        if item.checkState():
+        if item.checkState() == Qt.CheckState.Checked:
             self.batch_vars.append(item.data(VariableRole))
         else:
             self.batch_vars.remove(item.data(VariableRole))

--- a/orangecontrib/single_cell/widgets/owharmony.py
+++ b/orangecontrib/single_cell/widgets/owharmony.py
@@ -149,7 +149,7 @@ class OWHarmony(OWWidget):
 
 
     def __selected_batch_vars_changed(self, item):
-        if item.checkState():
+        if item.checkState() == Qt.CheckState.Checked:
             self.batch_vars.append(item.data(VariableRole))
         else:
             self.batch_vars.remove(item.data(VariableRole))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Batch effect and Harmony do not handle changes to batch variable selection properly,
I.e. ```if item.checkState():``` is always true. As a result batch_vars only ever grows in size, accumulating variables.

For Batch Effect Removal, toggling a variable on and off, results in (widget) error "All variables in domain should have unique names", which is misleading the user, and cannot be fixed except with "Clear widget settings". 

In Harmony on every toggle it takes longer to compute the result. 

##### Description of changes

Fix wrong condition for `checkState()`. It is an enum and always 'trueish'.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
