### PR TITLE
[FIX] Score Genes: Scorer selection update on PyQt6

### DIFF
--- a/orangecontrib/single_cell/tests/test_owscoregenes.py
+++ b/orangecontrib/single_cell/tests/test_owscoregenes.py
@@ -1,5 +1,8 @@
 import unittest
 
+from AnyQt.QtCore import Qt
+from AnyQt.QtWidgets import QStackedWidget, QCheckBox
+
 from orangecontrib.single_cell.widgets.owscoregenes import OWRank
 from Orange.widgets.tests.base import WidgetTest
 from Orange.data import DiscreteVariable, ContinuousVariable, Domain, Table
@@ -44,6 +47,17 @@ class TestOWScoreGenes(WidgetTest):
         self.send_signal(w1.Inputs.data, self.data)
         self.assertEqual(w1.selectionMethod, OWRank.SelectManual)
         self.assertSequenceEqual(w.selected_attrs, w1.selected_attrs)
+
+    def test_update_selected_scores(self):
+        w = self.widget
+        self.send_signal(w.Inputs.data, self.data)
+        stack = w.findChild(QStackedWidget)
+        box = stack.widget(2)  # for unsupervised
+        cb: QCheckBox = box.findChild(QCheckBox, "Mean")
+        cb.setCheckState(Qt.CheckState.Unchecked)
+        self.assertNotIn("Mean", w.selected_methods)
+        cb.setCheckState(Qt.CheckState.Checked)
+        self.assertIn("Mean", w.selected_methods)
 
 
 if __name__ == '__main__':

--- a/orangecontrib/single_cell/widgets/owscoregenes.py
+++ b/orangecontrib/single_cell/widgets/owscoregenes.py
@@ -630,8 +630,8 @@ class OWRank(OWWidget):
         sort_column = self.ranksModel.sortColumn() - 1  # -1 for '#' (discrete count) column
         self.sorting = (sort_column, sort_order)
 
-    def methodSelectionChanged(self, state, method_name):
-        if state == Qt.Checked:
+    def methodSelectionChanged(self, state: int, method_name: str):
+        if Qt.CheckState(state) == Qt.CheckState.Checked:
             self.selected_methods.add(method_name)
         elif method_name in self.selected_methods:
             self.selected_methods.remove(method_name)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

When using PyQt6 toggling the selected scorers only removes them from the view and never adds them back.

Applies on top of pr-418

##### Description of changes

Fix condition check due to type mismatch (int vs enum).

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
